### PR TITLE
When loading models/collections make the requested model update last

### DIFF
--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -28,17 +28,21 @@ describe 'Brainstem.Model', ->
       expect(base.data.storage('users').get(5).attributes).toEqual(response.users[0])
       expect(base.data.storage('users').get(6).attributes).toEqual(response.users[1])
 
-    it 'should update the associations before the new model', ->
-      response.tasks[0].assignee_ids = [5]
-      response.users = [{id: 5, name: 'Jon'}]
-
-      spy = spyOn(base.data, 'storage').andCallThrough()
-      model.updateStorageManager(response)
-      expect(spy.calls[0].args[0]).toEqual('users')
-      expect(spy.calls[1].args[0]).toEqual('tasks')
-
     it 'should work with an empty response', ->
-      model.updateStorageManager(count: 0, results: [])
+      expect( -> model.parse(tasks: [], results: [], count: 0)).not.toThrow()
+
+    describe 'updateStorageManager', ->
+      it 'should update the associations before the new model', ->
+        response.tasks[0].assignee_ids = [5]
+        response.users = [{id: 5, name: 'Jon'}]
+
+        spy = spyOn(base.data, 'storage').andCallThrough()
+        model.updateStorageManager(response)
+        expect(spy.calls[0].args[0]).toEqual('users')
+        expect(spy.calls[1].args[0]).toEqual('tasks')
+
+      it 'should work with an empty response', ->
+        expect( -> model.updateStorageManager(count: 0, results: [])).not.toThrow()
 
     it 'should return the first object from the result set', ->
       response.tasks.unshift([id: 2, name: 'Bobby'])

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -43,9 +43,12 @@ class window.Brainstem.Model extends Backbone.Model
   _parseResultsResponse: (resp) ->
     return resp unless resp['results']
 
-    key = resp['results'][0].key
-    id = resp['results'][0].id
-    _.find(resp[key], (mobj) -> mobj.id == id)
+    if resp['results'].length
+      key = resp['results'][0].key
+      id = resp['results'][0].id
+      _.find(resp[key], (mobj) -> mobj.id == id)
+    else
+      {}
 
 
   # Retreive details about a named association.  This is a class method.

--- a/vendor/assets/javascripts/brainstem/storage-manager.coffee
+++ b/vendor/assets/javascripts/brainstem/storage-manager.coffee
@@ -170,12 +170,9 @@ class window.Brainstem.StorageManager
 
         results = resp['results']
         keys = _.reject(_.keys(resp), (key) -> key == 'count' || key == 'results')
-        if _.isEmpty(results)
-          Brainstem.Utils.throwError("Received an empty response when trying to load #{name}")
-        else
-          primaryModelKey = results[0]['key']
-          keys.splice(keys.indexOf(primaryModelKey), 1)
-          keys.push(primaryModelKey)
+        unless _.isEmpty(results)
+          keys.splice(keys.indexOf(name), 1) if keys.indexOf(name) != -1
+          keys.push(name)
 
         for underscoredModelName in keys
           @storage(underscoredModelName).update resp[underscoredModelName]


### PR DESCRIPTION
This fixes a bug in global task tracker where we can update a story with an assignee that does not currently exist in the storage manager (for example, current user is not assigned to any other stories yet).  Previously, the story would get updated first which fires change events in the view before assignees/users collection would be updated with the new user.

Now we're pushing the primary key to the end of the response so all associations are updated in the storage manager before the primary one.

We assume, though, that only 1 type of primary model is being loaded.  When we return STI'd models (like lineitems) we'll have to push all of those keys after the association keys.
