### PR TITLE
StorageManager.errorInterceptor update to work with Backbone 1.0

### DIFF
--- a/spec/brainstem-expectation-spec.coffee
+++ b/spec/brainstem-expectation-spec.coffee
@@ -80,8 +80,7 @@ describe 'Brainstem Expectations', ->
 
         expectation.respond()
         expect(errorSpy).toHaveBeenCalled()
-        expect(errorSpy.mostRecentCall.args[0] instanceof Brainstem.Collection).toBe true
-        expect(errorSpy.mostRecentCall.args[1]).toEqual resp
+        expect(errorSpy.mostRecentCall.args[0]).toEqual resp
 
       it "does not trigger errors when asked not to", ->
         errorSpy = jasmine.createSpy()

--- a/vendor/assets/javascripts/brainstem/storage-manager.coffee
+++ b/vendor/assets/javascripts/brainstem/storage-manager.coffee
@@ -47,7 +47,7 @@ class window.Brainstem.StorageManager
     !!@collections[name]
 
   setErrorInterceptor: (interceptor) =>
-    @errorInterceptor = interceptor || (handler, modelOrCollection, options, jqXHR, requestParams) -> handler?(modelOrCollection, jqXHR)
+    @errorInterceptor = interceptor || (handler, modelOrCollection, options, jqXHR, requestParams) -> handler?(jqXHR)
 
   # Request a model to be loaded, optionally ensuring that associations be included as well.  A collection is returned immediately and is reset
   # when the load, and any dependent loads, are complete.


### PR DESCRIPTION
In [Backbone 1.0](http://htmlpreview.github.io/?https://raw.github.com/documentcloud/backbone/1.0.0/docs/backbone.html#section-198), wrapError is:

```
  var wrapError = function (model, options) {
    var error = options.error;
    options.error = function(resp) {
      if (error) error(model, resp, options);
      model.trigger('error', model, resp, options);
    };
  };
```

In [Backbone 0.92](http://htmlpreview.github.io/?https://raw.github.com/documentcloud/backbone/0.9.2/docs/backbone.html#section-173), it was:

```
  Backbone.wrapError = function(onError, originalModel, options) {
    return function(model, resp) {
      resp = model === originalModel ? resp : model;
      if (onError) {
        onError(originalModel, resp, options);
      } else {
        originalModel.trigger('error', originalModel, resp, options);
      }
    };
  };
```

The 0.92 wrapError inner function took (model, resp), so we used `handler?(modelOrCollection, jqXHR)`. The 1.0 wrapError inner function only takes (resp), so we need to change it to `handler?(jqXHR)`
