### PR TITLE
Return jqXhr

### DIFF
--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -595,6 +595,22 @@ describe 'Brainstem Storage Manager', ->
         collection = base.data.loadCollection "tasks", search: ""
         server.respond()
 
+    describe 'return values', ->
+      it 'adds the jQuery XHR object to the return values if returnValues is passed in', ->
+        baseXhr = $.ajax()
+        returnValues = {}
+
+        base.data.loadCollection "tasks", search: "the meaning of life", returnValues: returnValues
+        expect(returnValues.jqXhr).not.toBeUndefined()
+
+        # if it has most of the functions of a jQuery XHR object then it's probably a jQuery XHR object
+        jqXhrKeys = ['setRequestHeader', 'getAllResponseHeaders', 'getResponseHeader', 'overrideMimeType', 'abort']
+
+        for functionName in jqXhrKeys
+          funct = returnValues.jqXhr[functionName]
+          expect(funct).not.toBeUndefined()
+          expect(funct.toString()).toEqual(baseXhr[functionName].toString())
+
   describe "createNewCollection", ->
     it "makes a new collection of the appropriate type", ->
       expect(base.data.createNewCollection("tasks", [buildTask(), buildTask()]) instanceof App.Collections.Tasks).toBe true

--- a/vendor/assets/javascripts/brainstem/storage-manager.coffee
+++ b/vendor/assets/javascripts/brainstem/storage-manager.coffee
@@ -203,7 +203,10 @@ class window.Brainstem.StorageManager
         syncOptions.data.page = options.page
 
     syncOptions.data.search = search if search
-    Backbone.sync.call collection, 'read', collection, syncOptions
+    jqXhr = Backbone.sync.call collection, 'read', collection, syncOptions
+
+    if options.returnValues
+      options.returnValues.jqXhr = jqXhr
 
     collection
 


### PR DESCRIPTION
loadModel and loadCollection now take an optional `returnValues` option that takes an object that will get populated with the jQuery XHR object (for purposes like aborting requests).
