### PR TITLE
StorageManager#loadModel and #_handleNextLayer with error callbacks

### DIFF
--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -674,6 +674,22 @@ describe 'Brainstem Storage Manager', ->
         server.respond()
         expect(customHandler).toHaveBeenCalled()
 
+      it "should also get called any amount of layers deep", ->
+        errorHandler = jasmine.createSpy('errorHandler')
+        successHandler = jasmine.createSpy('successHandler')
+        taskOne = buildTask(id: 10, sub_task_ids: [12])
+        taskOneSub = buildTask(id: 12, parent_id: 10, sub_task_ids: [13], project_id: taskOne.get('workspace_id'))
+        respondWith server, "/api/tasks.json?include=sub_tasks&parents_only=true&per_page=20&page=1", data: { results: resultsArray("tasks", [taskOne]), tasks: resultsObject([taskOne, taskOneSub]) }
+        server.respondWith "GET", "/api/tasks.json?include=sub_tasks&only=12", [ 401, {"Content-Type": "application/json"}, JSON.stringify({ errors: ["Invalid OAuth 2 Request"]}) ]
+        base.data.loadCollection("tasks", filters: { parents_only: "true" }, include: [ "sub_tasks": ["sub_tasks"] ], success: successHandler, error: errorHandler)
+
+        expect(successHandler).not.toHaveBeenCalled()
+        expect(errorHandler).not.toHaveBeenCalled()
+        server.respond()
+        expect(successHandler).not.toHaveBeenCalled()
+        expect(errorHandler).toHaveBeenCalled()
+        expect(errorHandler.callCount).toEqual(1)
+
     describe "when no storage manager error interceptor is given", ->
       it "has a default error interceptor", ->
         manager = new Brainstem.StorageManager()

--- a/vendor/assets/javascripts/brainstem/storage-manager.coffee
+++ b/vendor/assets/javascripts/brainstem/storage-manager.coffee
@@ -100,7 +100,7 @@ class window.Brainstem.StorageManager
         expectedAdditionalLoads = @_countRequiredServerRequests(include) - 1
         if expectedAdditionalLoads > 0
           timesCalled = 0
-          @_handleNextLayer collection: firstLayerCollection, include: include, success: =>
+          @_handleNextLayer collection: firstLayerCollection, include: include, error: options.error, success: =>
             timesCalled += 1
             if timesCalled == expectedAdditionalLoads
               @_success(options, collection, firstLayerCollection)
@@ -123,8 +123,8 @@ class window.Brainstem.StorageManager
         map((m) -> if (a = m.get(association)) instanceof Backbone.Collection then a.models else a).
         flatten().uniq().compact().pluck("id").sort().value()
         newCollectionName = options.collection.model.associationDetails(association).collectionName
-        @_loadCollectionWithFirstLayer name: newCollectionName, only: association_ids, include: nextLevelInclude, success: (loadedAssociationCollection) =>
-          @_handleNextLayer(collection: loadedAssociationCollection, include: nextLevelInclude, success: options.success)
+        @_loadCollectionWithFirstLayer name: newCollectionName, only: association_ids, include: nextLevelInclude, error: options.error, success: (loadedAssociationCollection) =>
+          @_handleNextLayer(collection: loadedAssociationCollection, include: nextLevelInclude, error: options.error, success: options.success)
           options.success()
 
   _loadCollectionWithFirstLayer: (options) =>


### PR DESCRIPTION
StorageManager#loadModel will invoke an error callback if the result set  is empty
- The error callback is invoked (or silently breaks) when the server responds with 0 results.

A couple question for when the review process happens:
- What should the arguments be for the error callback? 
- Are we going to provide a default error callback? 

StorageManager#_handleNextLayer will pass the error callback to additional server requests. 
