### PR TITLE
loadModel uses show routes instead of index

### DIFF
--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -121,10 +121,10 @@ describe 'Brainstem Storage Manager', ->
       model = base.data.loadModel "time_entry", 1, cache: false
       expect(spy.mostRecentCall.args[1]['cache']).toBe(false)
 
-    it "invokes the error callback when the result set is empty", ->
+    it "invokes the error callback when the server responds with a 404", ->
       successSpy = jasmine.createSpy('successSpy')
       errorSpy = jasmine.createSpy('errorSpy')
-      respondWith server, "/api/time_entries?only=1337", data: { results: [] }
+      respondWith server, "/api/time_entries?only=1337", data: { results: [] }, status: 404
       base.data.loadModel "time_entry", 1337, success: successSpy, error: errorSpy
 
       server.respond()

--- a/vendor/assets/javascripts/brainstem/storage-manager.coffee
+++ b/vendor/assets/javascripts/brainstem/storage-manager.coffee
@@ -66,7 +66,6 @@ class window.Brainstem.StorageManager
       only: id
       model: model
       success: (collection) ->
-        return options.error?(model, id) unless collection.get(id)?
         model.setLoaded true, trigger: false
         model.set collection.get(id).attributes
         model.setLoaded true


### PR DESCRIPTION
Accomplishes this by passing the model to Backbone.sync instead of the collection.
