### PR TITLE
Add the parsing model to the storage manager instead of creating a new o...

### DIFF
--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -28,6 +28,14 @@ describe 'Brainstem.Model', ->
       expect(base.data.storage('users').get(5).attributes).toEqual(response.users[5])
       expect(base.data.storage('users').get(6).attributes).toEqual(response.users[6])
 
+    it 'should add the parsing model to the storage manager instead of making a new one', ->
+      response.tasks[1].title = 'Hello'
+      expect(base.data.storage('tasks').get(1)).toBeUndefined()
+
+      model.parse(response)
+      expect(base.data.storage('tasks').get(1)).toEqual(model)
+      expect(base.data.storage('tasks').get(1).get('title')).toEqual('Hello')
+
     it 'should work with an empty response', ->
       expect( -> model.parse(tasks: {}, results: [], count: 0)).not.toThrow()
 

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -38,7 +38,11 @@ class window.Brainstem.Model extends Backbone.Model
         if collectionModel
           collectionModel.set(attributes)
         else
-          collection.add(attributes)
+          if @brainstemKey == underscoredModelName && this.isNew()
+            @set(attributes)
+            collection.add(this)
+          else
+            collection.add(attributes)
 
   _parseResultsResponse: (resp) ->
     return resp unless resp['results']


### PR DESCRIPTION
This solves a bug for this workflow:

1) Creating a new `Brainstem.Model`
2) Saving it to the server.
3) Expecting the instance of the `Brainstem.Model` that you created to be added to the `storageManager`

**Example:**

```
var myModel = new Mavenlink.Models.Story(); // Brainstem Model
myModel.save({ title: "Foo" });
```

Prior to this patch `myModel` would never get added to the `storageManager` but instead `Brainstem.Model#updateStorageManager` would create a new model with the attributes.

This patch modifies the behavior of `Brainstem.Model#updateStorageManager` to set the attributes on `myModel` and add it to the `storageManager` instead of creating a new one.
