### PR TITLE
Fixed a bug where deleting stories in firefox does not work

### DIFF
--- a/vendor/assets/javascripts/brainstem/brainstem-sync.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-sync.coffee
@@ -57,8 +57,12 @@ Backbone.sync = (method, model, options) ->
       if beforeSend
         beforeSend.apply this, arguments
 
+  # Clear out default data for DELETE requests, fixes a firefox issue where this exception is thrown: JavaScript component does not have a method named: “available”
+  if params.type == 'DELETE'
+    params.data = null
+
   # Don't process data on a non-GET request.
-  if params.type != 'GET' && !options.emulateJSON && params.type != 'DELETE'
+  if params.type != 'GET' && !options.emulateJSON
     params.processData = false
 
   # If we're sending a `PATCH` request, and we're in an old Internet Explorer


### PR DESCRIPTION
jQuery seems to automatically add data: {} to the request options of the ajax DELETE request, and if this is not stringified, firefox throws up with this error:  JavaScript component does not have a method named: “available”
