### PR TITLE
Silent option for Brainstem.Model#get

### DIFF
--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -239,9 +239,17 @@ describe 'Brainstem.Model', ->
           timeEntry = new App.Models.TimeEntry(id: 5, task_id: 2)
           expect(timeEntry.get("project")).toBeFalsy()
 
-        it "should throw when we have an association id but it cannot be found", ->
-          timeEntry = new App.Models.TimeEntry(id: 5, task_id: 2)
-          expect(-> timeEntry.get("task")).toThrow()
+        describe "throwing exceptions when we have an association id that cannot be found" ,->
+          it "should throw when silent is not supplied or falsy", ->
+            timeEntry = new App.Models.TimeEntry(id: 5, task_id: 2)
+            expect(-> timeEntry.get("task")).toThrow()
+            expect(-> timeEntry.get("task", silent: false)).toThrow()
+            expect(-> timeEntry.get("task", silent: null)).toThrow()
+
+          it "should not throw when silent is true", ->
+            timeEntry = new App.Models.TimeEntry(id: 5, task_id: 2)
+            cb = -> timeEntry.get("task", silent: true)
+            expect(cb).not.toThrow()
 
       describe "HasMany associations", ->
         it "should return HasMany associations", ->
@@ -256,9 +264,17 @@ describe 'Brainstem.Model', ->
           project = new App.Models.Project(id: 5)
           expect(project.get("time_entries").models).toEqual []
 
-        it "should throw when we have an association id but it cannot be found", ->
-          project = new App.Models.Project(id: 5, time_entry_ids: [2, 5])
-          expect(-> project.get("time_entries")).toThrow()
+        describe "throwing exceptions when we have an association id but it cannot be found", ->
+          it "should throw when silent is falsy", ->
+            project = new App.Models.Project(id: 5, time_entry_ids: [2, 5])
+            expect(-> project.get("time_entries")).toThrow()
+            expect(-> project.get("time_entries", silent: false)).toThrow()
+            expect(-> project.get("time_entries", silent: null)).toThrow()
+
+          it "should not throw when silent is truthy", ->
+            project = new App.Models.Project(id: 5, time_entry_ids: [2, 5])
+            cb = -> project.get("time_entries", silent: true)
+            expect(cb).not.toThrow()
 
         it "should apply a sort order to has many associations if it is provided at time of get", ->
           task = buildAndCacheTask(id: 5, sub_task_ids: [103, 77, 99])

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -92,7 +92,12 @@ class window.Brainstem.Model extends Backbone.Model
       if details.type == "BelongsTo"
         id = @get(details.key) # project_id
         if id?
-          base.data.storage(details.collectionName).get(id) || (Brainstem.Utils.throwError("Unable to find #{field} with id #{id} in our cached #{details.collectionName} collection.  We know about #{base.data.storage(details.collectionName).pluck("id").join(", ")}"))
+          model = base.data.storage(details.collectionName).get(id)
+
+          if not model && not options.silent
+            Brainstem.Utils.throwError("Unable to find #{field} with id #{id} in our cached #{details.collectionName} collection.  We know about #{base.data.storage(details.collectionName).pluck("id").join(", ")}")
+
+          model
       else
         ids = @get(details.key) # time_entry_ids
         models = []
@@ -102,7 +107,7 @@ class window.Brainstem.Model extends Backbone.Model
             model = base.data.storage(details.collectionName).get(id)
             models.push(model)
             notFoundIds.push(id) unless model
-          if notFoundIds.length
+          if notFoundIds.length && not options.silent
             Brainstem.Utils.throwError("Unable to find #{field} with ids #{notFoundIds.join(", ")} in our cached #{details.collectionName} collection.  We know about #{base.data.storage(details.collectionName).pluck("id").join(", ")}")
         if options.order
           comparator = base.data.getCollectionDetails(details.collectionName).klass.getComparatorWithIdFailover(options.order)


### PR DESCRIPTION
Passing a `silent: true` option to Brainstem.Model#get will prevent `get` from throwing an exception if a model is not found.
