### PR TITLE
Adds cache invalidation to Brainstem collections.

### DIFF
--- a/spec/brainstem-collection-spec.coffee
+++ b/spec/brainstem-collection-spec.coffee
@@ -129,6 +129,19 @@ describe 'Brainstem.Collection', ->
         collection = base.data.createNewCollection 'tasks'
         expect(collection.getServerCount()).toBeUndefined()
 
+  describe '#invalidateCache', ->
+    it 'invalidates the cache object', ->
+      posts = (buildPost(message: "old post", reply_ids: []) for i in [1..5])
+      respondWith server, "/api/posts?include=replies&parents_only=true&per_page=5&page=1", resultsFrom: "posts", data: { count: posts.length, posts: posts }
+      loader = base.data.loadObject "posts", include: ["replies"], filters: { parents_only: "true" }, perPage: 5
+      
+      expect(loader.getCacheObject()).toBeUndefined()
+      server.respond()
+
+      expect(loader.getCacheObject().valid).toEqual true
+      loader.getCollection().invalidateCache()
+      expect(loader.getCacheObject().valid).toEqual false
+
   describe 'setLoaded', ->
     it "should set the values of @loaded", ->
       collection.setLoaded true

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -283,25 +283,41 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
         beforeEach ->
           loader.storageManager.storage('tasks').add taskOne
 
-          fakeCacheObject =
-            count: 1
-            results: [key: "tasks", id: taskOne.id]
-
-          loader.storageManager.getCollectionDetails('tasks').cache['updated_at:desc||||||'] = fakeCacheObject
-
-        context 'all of the cached models have their associations loaded', ->
+        context 'cache is valid', ->
           beforeEach ->
-            taskOne.set('project_id', buildAndCacheProject().id)
+            fakeCacheObject =
+              count: 1
+              results: [key: "tasks", id: taskOne.id]
+              valid: true
 
-          it 'calls #_onLoadSuccess with the models from the cache', ->
-            opts.include = ['project']
-            loader.setup(opts)
-            loader._checkCacheForData()
-            expect(loader._onLoadSuccess).toHaveBeenCalledWith([taskOne])
+            loader.storageManager.getCollectionDetails('tasks').cache['updated_at:desc||||||'] = fakeCacheObject
 
-        context 'all of the cached models do not have their associations loaded', ->
+          context 'all of the cached models have their associations loaded', ->
+            beforeEach ->
+              taskOne.set('project_id', buildAndCacheProject().id)
+
+            it 'calls #_onLoadSuccess with the models from the cache', ->
+              opts.include = ['project']
+              loader.setup(opts)
+              loader._checkCacheForData()
+              expect(loader._onLoadSuccess).toHaveBeenCalledWith([taskOne])
+
+          context 'all of the cached models do not have their associations loaded', ->
+            it 'returns false and does not call #_onLoadSuccess', ->
+              opts.include = ['project']
+              loader.setup(opts)
+              notFound(loader, opts)
+
+        context 'cache is invalid', ->
+          beforeEach ->
+            fakeCacheObject =
+              count: 1
+              results: [key: "tasks", id: taskOne.id]
+              valid: false
+
+            loader.storageManager.getCollectionDetails('tasks').cache['updated_at:desc||||||'] = fakeCacheObject
+
           it 'returns false and does not call #_onLoadSuccess', ->
-            opts.include = ['project']
             loader.setup(opts)
             notFound(loader, opts)
 

--- a/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
@@ -44,11 +44,17 @@ class window.Brainstem.Collection extends Backbone.Collection
     @get(id)
 
   getServerCount: ->
-    if @lastFetchOptions
-      base.data.getCollectionDetails(@lastFetchOptions.name)?.cache[@lastFetchOptions.cacheKey]?.count
+    @_getCacheObject()?.count
+
+  invalidateCache: ->
+    @_getCacheObject()?.valid = false
 
   toServerJSON: (method) ->
     @toJSON()
+
+  _getCacheObject: ->
+    if @lastFetchOptions
+      base.data.getCollectionDetails(@lastFetchOptions.name)?.cache[@lastFetchOptions.cacheKey]
 
   @getComparatorWithIdFailover: (order) ->
     [field, direction] = order.split(":")

--- a/vendor/assets/javascripts/brainstem/loaders/abstract-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/abstract-loader.coffee
@@ -94,7 +94,7 @@ class Brainstem.AbstractLoader
       # Check if we have a cache for this request and if so make sure that all of the requested includes for this layer are loaded on those models.
       cacheObject = @getCacheObject()
 
-      if cacheObject
+      if cacheObject && cacheObject.valid
         subset = _.map cacheObject.results, (result) => @storageManager.storage(result.key).get(result.id)
         if (_.all(subset, (model) => model.associationsAreLoaded(@loadOptions.thisLayerInclude)))
           @_onLoadSuccess(subset)

--- a/vendor/assets/javascripts/brainstem/loaders/collection-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/collection-loader.coffee
@@ -43,6 +43,7 @@ class Brainstem.CollectionLoader extends Brainstem.AbstractLoader
       cachedData =
         count: resp.count
         results: results
+        valid: true
 
       @storageManager.getCollectionDetails(@loadOptions.name).cache[@loadOptions.cacheKey] = cachedData
 


### PR DESCRIPTION
You can invalidate the cache by calling `Brainstem.Collection#invalidateCache`.

This sets `valid` on the cache object to `false` therefore subsequent `loadCollections` will find the cache object but see that it's not valid and hit the server.
