### PR TITLE
Cache Only Queries

### DIFF
--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -401,10 +401,9 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
           beforeEach ->
             spyOn(loader, '_shouldUseOnly').andReturn(true)
 
-          it 'sets data.only to be the difference between the only query and the already loaded ids', ->
-            loader.alreadyLoadedIds = ['1', '2']
+          it 'sets data.only to comma separated ids', ->
             opts.only = [1, 2, 3, 4]
-            expect(getSyncOptions(loader, opts).data.only).toEqual '3,4'
+            expect(getSyncOptions(loader, opts).data.only).toEqual '1,2,3,4'
 
         context '#_shouldUseOnly returns false', ->
           beforeEach ->

--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -549,11 +549,11 @@ describe 'Brainstem Storage Manager', ->
           expect(spy).toHaveBeenCalled()
           expect(spy2).toHaveBeenCalled()
 
-        it "only requests ids that we don't already have", ->
+        it "requests all ids even onces that that we already have", ->
           respondWith server, "/api/time_entries?include=project%2Ctask&only=2",
                       resultsFrom: "time_entries", data: { time_entries: [buildTimeEntry(task_id: null, project_id: 10, id: 2)], tasks: [], projects: [buildProject(id: 10)] }
-          respondWith server, "/api/time_entries?include=project%2Ctask&only=3",
-                      resultsFrom: "time_entries", data: { time_entries: [buildTimeEntry(task_id: null, project_id: 11, id: 3)], tasks: [], projects: [buildProject(id: 11)] }
+          respondWith server, "/api/time_entries?include=project%2Ctask&only=2%2C3",
+                      resultsFrom: "time_entries", data: { time_entries: [buildTimeEntry(task_id: null, project_id: 10, id: 2), buildTimeEntry(task_id: null, project_id: 11, id: 3)], tasks: [], projects: [buildProject(id: 10), buildProject(id: 11)] }
 
           collection = base.data.loadCollection "time_entries", include: ["project", "task"], only: 2
           expect(collection.loaded).toBe false
@@ -567,25 +567,6 @@ describe 'Brainstem Storage Manager', ->
           expect(collection2.length).toEqual 2
           expect(collection2.get(2).get('project').id).toEqual "10"
           expect(collection2.get(3).get('project').id).toEqual "11"
-
-        it "does request ids from the server again when they don't have all associations loaded yet", ->
-          respondWith server, "/api/time_entries?include=project&only=2",
-                      resultsFrom: "time_entries", data: { time_entries: [buildTimeEntry(project_id: 10, id: 2, task_id: 5)], projects: [buildProject(id: 10)] }
-          respondWith server, "/api/time_entries?include=project%2Ctask&only=2",
-                      resultsFrom: "time_entries", data: { time_entries: [buildTimeEntry(project_id: 10, id: 2, task_id: 5)], tasks: [buildTask(id: 5)], projects: [buildProject(id: 10)] }
-          respondWith server, "/api/time_entries?include=project%2Ctask&only=3",
-                      resultsFrom: "time_entries", data: { time_entries: [buildTimeEntry(project_id: 11, id: 3, task_id: null)], tasks: [], projects: [buildProject(id: 11)] }
-
-          base.data.loadCollection "time_entries", include: ["project"], only: 2
-          server.respond()
-          base.data.loadCollection "time_entries", include: ["project", "task"], only: 3
-          server.respond()
-          collection2 = base.data.loadCollection "time_entries", include: ["project", "task"], only: [2, 3]
-          expect(collection2.loaded).toBe false
-          server.respond()
-          expect(collection2.loaded).toBe true
-          expect(collection2.get(2).get('task').id).toEqual "5"
-          expect(collection2.length).toEqual 2
 
         it "doesn't go to the server if it doesn't need to", ->
           respondWith server, "/api/time_entries?include=project%2Ctask&only=2%2C3",

--- a/vendor/assets/javascripts/brainstem/loaders/abstract-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/abstract-loader.coffee
@@ -101,8 +101,8 @@ class Brainstem.AbstractLoader
   ###
   _checkCacheForData: ->
     if @loadOptions.only?
-      @alreadyLoadedIds = _.select @loadOptions.only, (id) => @cachedCollection.get(id)?.associationsAreLoaded(@loadOptions.thisLayerInclude)
-      if @alreadyLoadedIds.length == @loadOptions.only.length
+      alreadyLoadedIds = _.select @loadOptions.only, (id) => @cachedCollection.get(id)?.associationsAreLoaded(@loadOptions.thisLayerInclude)
+      if alreadyLoadedIds.length == @loadOptions.only.length
         # We've already seen every id that is being asked for and have all the associated data.
         @_onLoadSuccess(_.map @loadOptions.only, (id) => @cachedCollection.get(id))
         return @externalObject
@@ -238,7 +238,7 @@ class Brainstem.AbstractLoader
     syncOptions.data.include = @loadOptions.thisLayerInclude.join(",") if @loadOptions.thisLayerInclude.length
 
     if @loadOptions.only && @_shouldUseOnly()
-      syncOptions.data.only = _.difference(@loadOptions.only, @alreadyLoadedIds).join(",")
+      syncOptions.data.only = @loadOptions.only.join(",")
 
     syncOptions.data.order = @loadOptions.order if @loadOptions.order?
     _.extend(syncOptions.data, _(@loadOptions.filters).omit('include', 'only', 'order', 'per_page', 'page', 'limit', 'offset', 'search')) if _(@loadOptions.filters).keys().length

--- a/vendor/assets/javascripts/brainstem/loaders/collection-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/collection-loader.coffee
@@ -45,13 +45,7 @@ class Brainstem.CollectionLoader extends Brainstem.AbstractLoader
       valid: true
 
     @storageManager.getCollectionDetails(@loadOptions.name).cache[@loadOptions.cacheKey] = cachedData
-
-    if @loadOptions.only?
-      data = _.map(@loadOptions.only, (id) => @cachedCollection.get(id))
-    else
-      data = _.map(results, (result) => @storageManager.storage(result.key).get(result.id))
-
-    data
+    _.map(results, (result) => @storageManager.storage(result.key).get(result.id))
 
   _updateObjects: (object, data, silent = false) ->
     object.setLoaded true, trigger: false


### PR DESCRIPTION
- Moves the cache key logic out into it's own function as it was getting long.
- Adds onlys to the cache key.
- Caches only results that come back from the server (for server count).
