### PR TITLE
Update Collection fetch method so chained callbacks receive collection instance.

### DIFF
--- a/spec/brainstem-collection-spec.coffee
+++ b/spec/brainstem-collection-spec.coffee
@@ -140,14 +140,6 @@ describe 'Brainstem.Collection', ->
       expect(wrapSpy).toHaveBeenCalledWith(collection, jasmine.any(Object))
       expect(wrapSpy.mostRecentCall.args[1].error).toBe(options.error)
 
-    it 'returns a promise', ->
-      deferred =
-        pipe: -> { done: (-> { promise: -> 'le-promise' }) }
-
-      spyOn(base.data, 'loadObject').andReturn(deferred)
-      collection.model = App.Models.Post
-      expect(collection.fetch()).toEqual('le-promise')
-
     describe 'loading brainstem object', ->
       loadObjectSpy = options = null
 
@@ -311,6 +303,16 @@ describe 'Brainstem.Collection', ->
         server.respond()
 
         expect(collection.pluck('id')).toEqual(_(posts1).pluck('id'))
+
+      it 'passes collection instance to promise callbacks', ->
+        doneSpy = jasmine.createSpy('onDone')
+
+        respondWith(server, '/api/posts?per_page=5&page=1', resultsFrom: 'posts', data: { posts: posts1 })
+
+        collection.fetch().done(doneSpy)
+        server.respond()
+        
+        expect(doneSpy).toHaveBeenCalledWith collection
 
       it 'responds to requests with custom params', ->
         paramsOnDoneSpy = jasmine.createSpy('paramsOnDoneSpy')

--- a/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
@@ -84,9 +84,10 @@ class window.Brainstem.Collection extends Backbone.Collection
     
     @trigger('request', this, options.returnValues.jqXhr, options)
 
-    loader.pipe(-> loader.internalObject.models)
-      .done((response) =>
-        @lastFetchOptions = loader.externalObject.lastFetchOptions
+    loader.pipe(=> this)
+      .done((collection) ->
+        response = loader.internalObject.models
+        collection.lastFetchOptions = loader.externalObject.lastFetchOptions
 
         if options.add
           method = 'add'
@@ -95,10 +96,11 @@ class window.Brainstem.Collection extends Backbone.Collection
         else
           method = 'set'
 
-        @[method](response, options)
+        collection[method](response, options)
 
-        @trigger('sync', this, response, options)
-      ).promise()
+        collection.trigger('sync', collection, response, options)
+      )
+      .promise()
 
   refresh: (options = {}) ->
     @fetch _.extend(@lastFetchOptions, options, cache: false)


### PR DESCRIPTION
This passes the actual collection instance into the promise callback instead of an array of models. This makes `Collection#fetch` consistent with `Model#fetch`