### PR TITLE
Properly implement Brainstem.Collection#toServerJSON

### DIFF
--- a/spec/brainstem-collection-spec.coffee
+++ b/spec/brainstem-collection-spec.coffee
@@ -855,10 +855,10 @@ describe 'Brainstem.Collection', ->
 
   describe '#toServerJSON', ->
     beforeEach ->
-      spyOn(model, 'toServerJSON').andCallFake(-> @id) for model in collection.models
+      spyOn(model, 'toServerJSON').andCallThrough() for model in collection.models
 
     it 'returns model contents serialized using model server json', ->
-      expect(collection.toServerJSON()).toEqual(collection.pluck('id'))
+      expect(_(collection.toServerJSON()).pluck('id')).toEqual(collection.pluck('id'))
 
     it 'passes method to model method calls', ->
       collection.toServerJSON('update')

--- a/spec/brainstem-collection-spec.coffee
+++ b/spec/brainstem-collection-spec.coffee
@@ -854,10 +854,15 @@ describe 'Brainstem.Collection', ->
       expect(loader.getCacheObject().valid).toEqual false
 
   describe '#toServerJSON', ->
-    it 'calls through to toJSON', ->
-      spy = spyOn(collection, 'toJSON')
-      collection.toServerJSON()
-      expect(spy).toHaveBeenCalled()
+    beforeEach ->
+      spyOn(model, 'toServerJSON').andCallFake(-> @id) for model in collection.models
+
+    it 'returns model contents serialized using model server json', ->
+      expect(collection.toServerJSON()).toEqual(collection.pluck('id'))
+
+    it 'passes method to model method calls', ->
+      collection.toServerJSON('update')
+      expect(model.toServerJSON).toHaveBeenCalledWith('update') for model in collection.models
 
   describe '#setLoaded', ->
     it 'should set the values of @loaded', ->

--- a/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
@@ -189,7 +189,7 @@ class window.Brainstem.Collection extends Backbone.Collection
     @_getCacheObject()?.valid = false
 
   toServerJSON: (method) ->
-    @map (model) -> model.toServerJSON(method)
+    @map (model) -> _.extend(model.toServerJSON(method), id: model.id)
 
 
   #

--- a/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
@@ -2,6 +2,8 @@
 
 class window.Brainstem.Collection extends Backbone.Collection
 
+  model: Brainstem.Model
+
   @OPTION_KEYS = [
     'name'
     'include'
@@ -187,7 +189,7 @@ class window.Brainstem.Collection extends Backbone.Collection
     @_getCacheObject()?.valid = false
 
   toServerJSON: (method) ->
-    @toJSON()
+    @map (model) -> model.toServerJSON(method)
 
 
   #

--- a/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
@@ -67,7 +67,7 @@ class window.Brainstem.Collection extends Backbone.Collection
 
   fetch: (options) ->
     options = if options then _.clone(options) else {}
-    
+
     options.parse = options.parse ? true
     options.name = options.name ? @model?.prototype.brainstemKey
     options.returnValues ?= {}
@@ -83,7 +83,7 @@ class window.Brainstem.Collection extends Backbone.Collection
     Brainstem.Utils.wrapError(this, options)
 
     loader = base.data.loadObject(options.name, _.extend({}, @firstFetchOptions, options))
-    
+
     @trigger('request', this, options.returnValues.jqXhr, options)
 
     loader.pipe(-> loader.internalObject.models)


### PR DESCRIPTION
It now calls appropriate method on alls when serializing collection instead of deferring to Backbone method. This allows blacklisting to be applied to entire collections during serialization