### PR TITLE
Support Brainstem.Collection#getServerCount when expectations are enabled

### DIFF
--- a/spec/brainstem-expectation-spec.coffee
+++ b/spec/brainstem-expectation-spec.coffee
@@ -78,6 +78,20 @@ describe 'Brainstem Expectations', ->
       it "mocks cache object to return mocked count from getServerCount", ->
         expect(collection.getServerCount()).toEqual 20
 
+    context "count option is not supplied", ->
+      collection = null
+
+      beforeEach ->
+        expectation = manager.stub "projects",
+          response: (stub) ->
+            stub.results = [project1, project2]
+
+        collection = manager.loadCollection "projects"
+        expectation.respond()
+
+      it "mocks cache object to return default count (result length) from getServerCount", ->
+        expect(collection.getServerCount()).toEqual 2
+
     describe 'recursive loading', ->
       context 'recursive option is false', ->
         it "should not try to recursively load includes in an expectation", ->

--- a/spec/brainstem-expectation-spec.coffee
+++ b/spec/brainstem-expectation-spec.coffee
@@ -63,6 +63,21 @@ describe 'Brainstem Expectations', ->
       expect(collection.get(1).get("tasks").models).toEqual [task1]
       expect(collection.get(2).get("tasks").models).toEqual []
 
+    context "count option is supplied", ->
+      collection = null
+
+      beforeEach ->
+        expectation = manager.stub "projects",
+          count: 20
+          response: (stub) ->
+            stub.results = [project1, project2]
+
+        collection = manager.loadCollection "projects"
+        expectation.respond()
+
+      it "mocks cache object to return mocked count from getServerCount", ->
+        expect(collection.getServerCount()).toEqual 20
+
     describe 'recursive loading', ->
       context 'recursive option is false', ->
         it "should not try to recursively load includes in an expectation", ->

--- a/vendor/assets/javascripts/brainstem/brainstem-expectation.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-expectation.coffee
@@ -13,12 +13,13 @@ class window.Brainstem.Expectation
     @matches = []
     @recursive = false
     @triggerError = options.triggerError
+    @count = options.count
     @immediate = options.immediate
     delete options.immediate
     @associated = {}
     @collections = {}
     @requestQueue = []
-    @options.response(@) if @options.response?
+    @options.response(this) if @options.response?
 
 
   #
@@ -91,6 +92,13 @@ class window.Brainstem.Expectation
   _handleCollectionResults: (loader) ->
     return if not @results
 
+    cachedData =
+      count: @count
+      results: @results
+      valid: true
+
+    @manager.getCollectionDetails(loader.loadOptions.name).cache[loader.loadOptions.cacheKey] = cachedData
+
     for result in @results
       if result instanceof Brainstem.Model
         @manager.storage(result.brainstemKey).update [result]
@@ -115,7 +123,7 @@ class window.Brainstem.Expectation
       attributes = _.omit @result, 'key'
 
     if !key
-      throw 'Brainstem key is required on the result (brainstemKey on model or key in JSON)'
+      throw Brainstem.Error('Brainstem key is required on the result (brainstemKey on model or key in JSON)')
 
     existingModel = @manager.storage(key).get(attributes.id)
 

--- a/vendor/assets/javascripts/brainstem/brainstem-expectation.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-expectation.coffee
@@ -93,7 +93,7 @@ class window.Brainstem.Expectation
     return if not @results
 
     cachedData =
-      count: @count
+      count: @count ? @results.length
       results: @results
       valid: true
 

--- a/vendor/assets/javascripts/brainstem/storage-manager.coffee
+++ b/vendor/assets/javascripts/brainstem/storage-manager.coffee
@@ -169,7 +169,7 @@ class window.Brainstem.StorageManager
         expectation.recordRequest(loader)
         return
     throw  new Error("No expectation matched #{name} with #{JSON.stringify loader.originalOptions}")
-    
+
 
   #
   # Private


### PR DESCRIPTION
This PR adds support to mock collection cache object with count when stubbing:

```javascript
expectation = storageManagerInstance.stub('projects', { count: 100 });
collection = new Projects();

collection.fetch();
expectation.respond();

collection.getServerCount();
// 100
```