### PR TITLE
Fixes date parsing for fields that include an ISO8601 date

### DIFF
--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -196,6 +196,10 @@ describe 'Brainstem.Model', ->
         expect(base.data.storage('users').get(5).get('created_at')).toEqual(1361820357000)
         expect(base.data.storage('users').get(6).get('created_at')).toEqual(1359573957000)
 
+      it "does not handle ISO 8601 dates with other characters", ->
+        parsed = model.parse({created_at: "blargh 2013-01-25T11:25:57-08:00 churgh"})
+        expect(parsed.created_at).toEqual("blargh 2013-01-25T11:25:57-08:00 churgh")
+
   describe 'associations', ->
 
     class TestClass extends Brainstem.Model

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -45,7 +45,7 @@ class window.Brainstem.Model extends Backbone.Model
   @parse: (modelObject) ->
     for k,v of modelObject
       # Date.parse will parse ISO 8601 in ECMAScript 5, but we include a shim for now
-      if /\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}[-+]\d{2}:\d{2}/.test(v)
+      if /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}[-+]\d{2}:\d{2}$/.test(v)
         modelObject[k] = Date.parse(v)
     return modelObject
 


### PR DESCRIPTION
This fixes fields that contain an ISO8601 date along with other characters and converts into NaN.  We now check that the field is ONLY an ISO8601 date and nothing else.

Note: if a field contains ONLY an ISO8601 date, then it will be converted to epoch time.

@jrolfs @cantino 