### PR TITLE
Pass jqXhr to promise that Brainstem.Collection#fetch returns

### DIFF
--- a/spec/brainstem-collection-spec.coffee
+++ b/spec/brainstem-collection-spec.coffee
@@ -85,7 +85,7 @@ describe 'Brainstem.Collection', ->
 
       it 'throws a "BrainstemError"', ->
         expect(-> collection.fetch()).toThrow()
-    
+
     context 'collection has model without a brainstemKey defined', ->
       beforeEach ->
         collection.model = new Backbone.Model()
@@ -96,7 +96,6 @@ describe 'Brainstem.Collection', ->
     context 'the collection has brainstemKey defined', ->
       beforeEach ->
         collection.model = App.Models.Post
-        
 
       it 'does not throw', ->
         expect(-> collection.fetch()).not.toThrow()
@@ -303,6 +302,17 @@ describe 'Brainstem.Collection', ->
 
         options = { page: 1, perPage: 5 }
         collection = new App.Collections.Posts(null, options)
+
+      it 'returns a promise with jqXhr methods', ->
+        respondWith(server, '/api/posts?per_page=5&page=1', resultsFrom: 'posts', data: { posts: posts1 })
+
+        jqXhr = $.ajax()
+        promise = collection.fetch()
+
+        for key, value of jqXhr
+          object = {}
+          object[key] = jasmine.any(value.constructor)
+          expect(promise).toEqual jasmine.objectContaining(object)
 
       it 'updates collection with response', ->
         respondWith(server, '/api/posts?per_page=5&page=1', resultsFrom: 'posts', data: { posts: posts1 })

--- a/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
@@ -84,8 +84,9 @@ class window.Brainstem.Collection extends Backbone.Collection
     Brainstem.Utils.wrapError(this, options)
 
     loader = base.data.loadObject(options.name, _.extend({}, @firstFetchOptions, options))
+    xhr = options.returnValues.jqXhr
 
-    @trigger('request', this, options.returnValues.jqXhr, options)
+    @trigger('request', this, xhr, options)
 
     loader.pipe(-> loader.internalObject.models)
       .done((response) =>
@@ -101,7 +102,7 @@ class window.Brainstem.Collection extends Backbone.Collection
         @[method](response, options)
 
         @trigger('sync', this, response, options)
-      ).promise()
+      ).promise(xhr)
 
   refresh: (options = {}) ->
     @fetch _.extend(@lastFetchOptions, options, cache: false)


### PR DESCRIPTION
Currently we return a simple promise, however vanilla Backbone actually returns
the raw value returned from the sync method. The raw value returned from sync is
the promise returned from `$.ajax` which includes the `jqXhr` API as well. This PR
adds the `jqXhr` API to the promise returned from `Brainstem.Collection#fetch` by
passing the `jqXhr` into the final `promise` call. This achieves better API
adherence to Backbone's fetch method and more importantly allows us to abort the
request and access response headers etc.