### PR TITLE
Don't throw an error when a association id is set to an empty string

### DIFF
--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -556,6 +556,13 @@ describe 'Brainstem.Model', ->
             it "should return association", ->
               expect(post.get("subject")).toEqual base.data.storage("projects").get(10)
 
+        describe 'when a form sets an association id to an empty string', ->
+          beforeEach ->
+            timeEntry.set('project_id', '')
+
+          it 'should not throw a Brainstem error', ->
+            expect(-> timeEntry.get("project")).not.toThrow()
+
       describe "HasMany associations", ->
         project = null
 

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -562,6 +562,7 @@ describe 'Brainstem.Model', ->
 
           it 'should not throw a Brainstem error', ->
             expect(-> timeEntry.get("project")).not.toThrow()
+            expect(timeEntry.get("project")).toBe(undefined)
 
       describe "HasMany associations", ->
         project = null

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -58,7 +58,7 @@ class window.Brainstem.Model extends Backbone.Model
     if details = @constructor.associationDetails(field)
       if details.type == "BelongsTo"
         pointer = super(details.key) # project_id
-        if pointer?
+        if pointer
           if details.polymorphic
             id = pointer.id
             collectionName = pointer.key


### PR DESCRIPTION
In mobile, we follow the pattern of serializing forms with hidden attributes for associations. We want Brainstem to ignore fields for associations where those fields are falsey not just null. Here we are not worried about an id of 0.

-- Ben's M

![screen shot 2015-11-02 at 11 58 09 am](https://cloud.githubusercontent.com/assets/9451001/10892895/b3dcff16-815a-11e5-8084-6fb25d8298db.png)
