### PR TITLE
Return jqXHR wrapped promise from Model#fetch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.1.5
 
 before_install: gem install bundler
 

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -31,9 +31,16 @@ describe 'Brainstem.Model', ->
         expect(-> model.fetch()).not.toThrow()
 
     it 'calls wrapError', ->
+      options =
+        only: [model.id],
+        parse: true,
+        name: 'posts',
+        cache: false
+        returnValues: jasmine.any(Object)
+
       spyOn(Brainstem.Utils, 'wrapError')
 
-      model.fetch(options = {only: [model.id], parse: true, name: 'posts', cache: false})
+      model.fetch(options)
 
       expect(Brainstem.Utils.wrapError).toHaveBeenCalledWith(model, options)
 
@@ -45,7 +52,14 @@ describe 'Brainstem.Model', ->
 
       expect(base.data.loadObject).toHaveBeenCalledWith(
         'tasks',
-        { only: [model.id], parse: true, name: 'tasks', error: jasmine.any(Function), cache: false },
+        {
+          only: [model.id],
+          parse: true,
+          name: 'tasks',
+          error: jasmine.any(Function),
+          cache: false
+          returnValues: jasmine.any(Object)
+        },
         isCollection: false
       )
 
@@ -59,7 +73,16 @@ describe 'Brainstem.Model', ->
       model.fetch()
       deferred.resolve(newModel)
 
-      expect(model.trigger).toHaveBeenCalledWith('sync', newModel, {only: [model.id], name: 'tasks', parse: true, error: jasmine.any(Function), cache: false})
+      expect(model.trigger).toHaveBeenCalledWith(
+        'sync', newModel,
+        {
+          only: [model.id],
+          name: 'tasks',
+          parse: true,
+          error: jasmine.any(Function),
+          cache: false, returnValues: jasmine.any(Object)
+        }
+      )
 
     it 'returns a promise', ->
       promise = (new $.Deferred).promise()
@@ -79,6 +102,17 @@ describe 'Brainstem.Model', ->
 
         expect(model.attributes).toEqual(task.attributes)
 
+      it 'returns a promise with jqXhr methods', ->
+        task = buildTask()
+        respondWith(server, '/api/tasks/1', resultsFrom: 'tasks', data: task)
+
+        jqXhr = $.ajax()
+        promise = model.fetch()
+
+        for key, value of jqXhr
+          object = {}
+          object[key] = jasmine.any(value.constructor)
+          expect(promise).toEqual jasmine.objectContaining(object)
 
   describe '#parse', ->
     response = null

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -80,7 +80,8 @@ describe 'Brainstem.Model', ->
           name: 'tasks',
           parse: true,
           error: jasmine.any(Function),
-          cache: false, returnValues: jasmine.any(Object)
+          cache: false,
+          returnValues: jasmine.any(Object)
         }
       )
 

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -111,6 +111,7 @@ class window.Brainstem.Model extends Backbone.Model
     options.parse = options.parse ? true
     options.name = options.name ? @brainstemKey
     options.cache = false
+    options.returnValues ?= {}
 
     unless options.name
       Brainstem.Utils.throwError('Either model must have a brainstemKey defined or name option must be provided')
@@ -121,7 +122,7 @@ class window.Brainstem.Model extends Backbone.Model
       .done((response) =>
         @trigger('sync', response, options)
       )
-      .promise()
+      .promise(options.returnValues.jqXhr)
 
   # Handle create and update responses with JSON root keys
   parse: (resp, xhr) ->


### PR DESCRIPTION
Return a [`jqXHR`](http://api.jquery.com/Types/#jqXHR) object wrapped in a jQuery [`promise`](https://api.jquery.com/promise/) just as we do for `Collection#fetch`. This allows the actual request to be aborted and exposes other request information about the native request.