### PR TITLE
Ensure array is returned in all cases in _modelOrObj

### DIFF
--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -662,11 +662,18 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
         collection.add([new Backbone.Model(), new Backbone.Model])
         expect(loader._modelsOrObj(collection)).toEqual(collection.models)
 
-    context 'obj is not a Backbone.Collection', ->
-      it 'returns the obj or an empty array', ->
+    context 'obj is a single object', ->
+      it 'returns obj wrapped in an array', ->
+        obj = new Backbone.Model()
+        expect(loader._modelsOrObj(obj)).toEqual([obj])
+
+    context 'obj is an array', ->
+      it 'returns obj', ->
         obj = []
         expect(loader._modelsOrObj(obj)).toEqual(obj)
 
+    context 'obj is undefined', ->
+      it 'returns an empty array', ->
         obj = null
         expect(loader._modelsOrObj(obj)).toEqual([])
 

--- a/vendor/assets/javascripts/brainstem/loaders/abstract-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/abstract-loader.coffee
@@ -318,9 +318,12 @@ class Brainstem.AbstractLoader
   _modelsOrObj: (obj) ->
     if obj instanceof Backbone.Collection
       obj.models
+    else if obj instanceof Array
+      obj
+    else if obj
+      [obj]
     else
-      obj || [] # TODO: revisit this.. we shouldn't be getting to this stage.
-
+      []
 
   # Events
 


### PR DESCRIPTION
This PR updates `_modelsOrObj` to always return an array, even if `obj` is a single model. This is necessary because of this:

https://github.com/mavenlink/brainstem-js/blob/return_array_from_modelorobj/vendor/assets/javascripts/brainstem/loaders/abstract-loader.coffee#L106

If the `obj` inside of this function is a singular model, then `_getIdsForAssociation` chokes because it tries to pluck `id` from each of the attributes of that model, rather than the id from each model in an array or collection. If `obj` is undefined, we just return an empty array.

@ahuth @jrolfs mind taking a look?

cc @arleigh-atkinson 