### PR TITLE
Cache newly fetched model references in storage manager

### DIFF
--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -97,21 +97,38 @@ describe 'Brainstem.Model', ->
 
     describe 'integration', ->
       it 'fetches model', ->
-        task = buildTask()
-        respondWith(server, '/api/tasks/1', resultsFrom: 'tasks', data: task)
+        updatedModel = buildTask()
+
+        respondWith(server, "/api/tasks/#{model.id}", resultsFrom: 'tasks', data: updatedModel)
 
         model.fetch()
         server.respond()
 
-        expect(model.attributes).toEqual(task.attributes)
+        expect(model.attributes).toEqual(updatedModel.attributes)
 
       it 'caches new model reference on fetch', ->
-        respondWith(server, '/api/tasks/1', resultsFrom: 'tasks', data: model)
+        newTask = buildTask()
 
-        model.fetch()
+        respondWith(server, "/api/tasks/#{newTask.id}", resultsFrom: 'tasks', data: newTask)
+
+        newModel = new App.Models.Task(id: newTask.id)
+        newModel.fetch()
+
         server.respond()
 
-        expect(base.data.storage('tasks').get(model.id)).toEqual(model)
+        expect(base.data.storage('tasks').get(newModel.id)).toEqual(newModel)
+
+      it 'updates new model reference', ->
+        task = buildAndCacheTask()
+
+        respondWith(server, "/api/tasks/#{task.id}", resultsFrom: 'tasks', data: task)
+
+        newModel = new App.Models.Task(id: task.id)
+        newModel.fetch()
+
+        server.respond()
+
+        expect(task.attributes).toEqual(newModel.attributes)
 
       context 'model reference already exists in cache', ->
         it 'does not duplicate model reference ', ->

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -34,6 +34,12 @@ describe 'Brainstem.Model', ->
           expect(-> new App.Models.Task(id: model.id)).not.toThrow()
 
       context 'model is cached in storage manager', ->
+        context '"cached" option is set to `false`', ->
+          beforeEach ->
+            newModel = new App.Models.Task({ id: model.id}, { cached: false })
+
+          itReturnsNewInstance()
+
         context 'new model attributes are valid', ->
           beforeEach ->
             spyOn(model, '_validate').andReturn(true)
@@ -82,6 +88,24 @@ describe 'Brainstem.Model', ->
         newModel = new App.Models.Task()
 
       itReturnsNewInstance()
+
+  describe '#clone', ->
+    cachedModel = clonedModel = clonedCachedModel = null
+
+    beforeEach ->
+      model = buildTask()
+      cachedModel = buildAndCacheTask()
+
+      clonedModel = model.clone()
+      clonedCachedModel = cachedModel.clone()
+
+    it 'clones model', ->
+      expect(model.attributes).toEqual(clonedModel.attributes)
+      expect(model.cid).not.toEqual(clonedModel.cid)
+
+    it 'clones cached model', ->
+      expect(cachedModel.attributes).toEqual(clonedCachedModel.attributes)
+      expect(cachedModel.cid).not.toEqual(clonedCachedModel.cid)
 
   describe '#fetch', ->
     beforeEach ->

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -200,7 +200,7 @@ describe 'Brainstem.Model', ->
 
     describe 'integration', ->
       it 'fetches model', ->
-        updatedModel = buildTask()
+        updatedModel = buildTask(description: 'updated description')
 
         respondWith(server, "/api/tasks/#{model.id}", resultsFrom: 'tasks', data: updatedModel)
 

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -17,7 +17,7 @@ describe 'Brainstem.Model', ->
         expect(newModel).toEqual jasmine.any(App.Models.Task)
 
     beforeEach ->
-      model = base.data.storage('tasks').add(buildTask())
+      model = base.data.storage('tasks').add(buildTask(project_id: 1))
 
     context 'id is provided', ->
       context 'storage manager has not been created', ->
@@ -40,6 +40,29 @@ describe 'Brainstem.Model', ->
             newModel = new App.Models.Task(id: model.id)
 
           itReturnsCachedInstance()
+
+          context 'model class does not define associations', ->
+            beforeEach ->
+              model = base.data.storage('users').add(buildUser())
+              newModel = new App.Models.User(id: model.id)
+
+            itReturnsCachedInstance()
+
+          context 'association attributes are provided', ->
+            beforeEach ->
+              newModel = new App.Models.Task(id: model.id, project_id: 2)
+
+            itReturnsCachedInstance()
+
+            it 'does not overwrite existing association attributes', ->
+              expect(+newModel.get('project_id')).toEqual 1
+
+            context 'with blacklist option', ->
+              beforeEach ->
+                newModel = new App.Models.Task({ id: model.id, project_id: 2 }, { blacklist: [] })
+
+              it 'does overwrite the existing association attributes', ->
+                expect(+newModel.get('project_id')).toEqual 2
 
         context 'new model attributes are invalid', ->
           beforeEach ->

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -36,7 +36,7 @@ describe 'Brainstem.Model', ->
       context 'model is cached in storage manager', ->
         context '"cached" option is set to `false`', ->
           beforeEach ->
-            newModel = new App.Models.Task({ id: model.id}, { cached: false })
+            newModel = new App.Models.Task({ id: model.id }, { cached: false })
 
           itReturnsNewInstance()
 

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -20,6 +20,19 @@ describe 'Brainstem.Model', ->
       model = base.data.storage('tasks').add(buildTask())
 
     context 'id is provided', ->
+      context 'storage manager has not been created', ->
+        storageManager = null
+
+        beforeEach ->
+          storageManager = base.data
+          delete window.base
+
+        afterEach ->
+          base = { data: storageManager }
+
+        it 'does not throw an error trying to access storage manager', ->
+          expect(-> new App.Models.Task(id: model.id)).not.toThrow()
+
       context 'model is cached in storage manager', ->
         context 'new model attributes are valid', ->
           beforeEach ->

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -271,14 +271,19 @@ describe 'Brainstem.Model', ->
       it 'should update the associations before the new model', ->
         spyOn(base.data, 'storage').andCallThrough()
 
-        findIndex = (key) -> base.data.storage.calls.findIndex((call) -> call.args[0] == key)
-
         response.tasks[1].assignee_ids = [5]
         response.users = { 5: {id: 5, name: 'Jon'} }
 
         model.updateStorageManager(response)
 
-        expect(findIndex('users')).toBeLessThan(findIndex('tasks'))
+        usersIndex = tasksIndex = null
+
+        _.each base.data.storage.calls, (call, index) ->
+          switch call.args[0]
+            when 'users' then usersIndex = index
+            when 'tasks' then tasksIndex = index
+
+        expect(usersIndex).toBeLessThan(tasksIndex)
 
       it 'should work with an empty response', ->
         expect( -> model.updateStorageManager(count: 0, results: [])).not.toThrow()

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -42,7 +42,7 @@ describe 'Brainstem.Model', ->
 
       model.fetch(options)
 
-      expect(Brainstem.Utils.wrapError).toHaveBeenCalledWith(model, options)
+      expect(Brainstem.Utils.wrapError).toHaveBeenCalledWith(model, jasmine.objectContaining(options))
 
     it 'calls loadObject', ->
       promise = done: (-> {promise: (->)})
@@ -59,6 +59,7 @@ describe 'Brainstem.Model', ->
           error: jasmine.any(Function),
           cache: false
           returnValues: jasmine.any(Object)
+          model: model
         },
         isCollection: false
       )
@@ -82,6 +83,7 @@ describe 'Brainstem.Model', ->
           error: jasmine.any(Function),
           cache: false,
           returnValues: jasmine.any(Object)
+          model: model
         }
       )
 
@@ -94,7 +96,7 @@ describe 'Brainstem.Model', ->
       expect(model.fetch()).toEqual(promise)
 
     describe 'integration', ->
-      it 'something', ->
+      it 'fetches model', ->
         task = buildTask()
         respondWith(server, '/api/tasks/1', resultsFrom: 'tasks', data: task)
 
@@ -102,6 +104,14 @@ describe 'Brainstem.Model', ->
         server.respond()
 
         expect(model.attributes).toEqual(task.attributes)
+
+      it 'caches new model reference on fetch', ->
+        respondWith(server, '/api/tasks/1', resultsFrom: 'tasks', data: model)
+
+        model.fetch()
+        server.respond()
+
+        expect(base.data.storage('tasks').get(model.id)).toEqual(model)
 
       it 'returns a promise with jqXhr methods', ->
         task = buildTask()

--- a/spec/brainstem-model-spec.coffee
+++ b/spec/brainstem-model-spec.coffee
@@ -113,6 +113,15 @@ describe 'Brainstem.Model', ->
 
         expect(base.data.storage('tasks').get(model.id)).toEqual(model)
 
+      context 'model reference already exists in cache', ->
+        it 'does not duplicate model reference ', ->
+          respondWith(server, '/api/tasks/1', resultsFrom: 'tasks', data: model)
+
+          model.fetch()
+          server.respond()
+
+          expect(base.data.storage('tasks').where(id: model.id).length).toEqual(1)
+
       it 'returns a promise with jqXhr methods', ->
         task = buildTask()
         respondWith(server, '/api/tasks/1', resultsFrom: 'tasks', data: task)

--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -449,7 +449,7 @@ describe 'Brainstem Storage Manager', ->
           collection.bind "reset", checkStructure
           expect(success).not.toHaveBeenCalled()
           server.respond()
-          expect(success).toHaveBeenCalledWith(collection)
+          expect(success.mostRecentCall.args[0].toJSON()).toEqual(collection.toJSON())
           expect(callCount).toEqual 3
 
       describe "caching", ->

--- a/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-collection.coffee
@@ -113,7 +113,7 @@ class window.Brainstem.Collection extends Backbone.Collection
     models = models.models if models.models?
     for model in models
       model = this.model.parse(model) if this.model.parse?
-      backboneModel = @_prepareModel(model)
+      backboneModel = @_prepareModel(model, blacklist: [])
       if backboneModel
         if modelInCollection = @get(backboneModel.id)
           modelInCollection.set backboneModel.attributes

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -13,7 +13,7 @@ class window.Brainstem.Model extends Backbone.Model
   # Init
 
   constructor: (attributes = {}, options = {}) ->
-    if attributes.id && @brainstemKey && base?.data
+    if options.cached != false && attributes.id && @brainstemKey && base?.data
       existing = base.data.storage(@brainstemKey).get(attributes.id)
       blacklist = options.blacklist || @_associationKeyBlacklist()
       valid = existing?.set(_.omit(attributes, blacklist))
@@ -243,6 +243,9 @@ class window.Brainstem.Model extends Backbone.Model
 
   #
   # Private
+
+  clone: ->
+    new this.constructor(this.attributes, { cached: false })
 
   _parseResultsResponse: (resp) ->
     return resp unless resp['results']

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -13,7 +13,7 @@ class window.Brainstem.Model extends Backbone.Model
   # Init
 
   constructor: (attributes = {}, options = {}) ->
-    if attributes.id && @brainstemKey
+    if attributes.id && @brainstemKey && base?.data
       existing = base.data.storage(@brainstemKey).get(attributes.id)
       valid = existing?.set(attributes)
 

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -10,6 +10,19 @@ class window.Brainstem.Model extends Backbone.Model
 
 
   #
+  # Init
+
+  constructor: (attributes = {}, options = {}) ->
+    if attributes.id && @brainstemKey
+      existing = base.data.storage(@brainstemKey).get(attributes.id)
+      valid = existing?.set(attributes)
+
+      return existing if valid
+
+    super
+
+
+  #
   # Class Methods
 
   # Retreive details about a named association.  This is a class method.

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -15,11 +15,20 @@ class window.Brainstem.Model extends Backbone.Model
   constructor: (attributes = {}, options = {}) ->
     if attributes.id && @brainstemKey && base?.data
       existing = base.data.storage(@brainstemKey).get(attributes.id)
-      valid = existing?.set(attributes)
+      blacklist = options.blacklist || @_associationKeyBlacklist()
+      valid = existing?.set(_.omit(attributes, blacklist))
 
       return existing if valid
 
     super
+
+  _associationKeyBlacklist: ->
+    return [] unless @constructor.associations
+
+    _.chain(@constructor.associations)
+      .keys()
+      .map((association) => @constructor.associationDetails(association).key)
+      .value()
 
 
   #

--- a/vendor/assets/javascripts/brainstem/brainstem-model.coffee
+++ b/vendor/assets/javascripts/brainstem/brainstem-model.coffee
@@ -112,6 +112,7 @@ class window.Brainstem.Model extends Backbone.Model
     options.name = options.name ? @brainstemKey
     options.cache = false
     options.returnValues ?= {}
+    options.model = this
 
     unless options.name
       Brainstem.Utils.throwError('Either model must have a brainstemKey defined or name option must be provided')

--- a/vendor/assets/javascripts/brainstem/loaders/model-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/model-loader.coffee
@@ -34,18 +34,19 @@ class Brainstem.ModelLoader extends Brainstem.AbstractLoader
     storage = @storageManager.storage(@_getCollectionName())
     model = @loadOptions.model
 
-    storage.add(model, remove: false) if model
+    storage.add(model, remove: false) if model && model.id
 
-    @internalObject = model || storage.get(id) || @storageManager.createNewModel(@loadOptions.name, id: id)
-    @externalObject = @internalObject
+    @internalObject = storage.get(id) || @storageManager.createNewModel(@loadOptions.name, id: id)
+    @externalObject = model || @internalObject
 
   _updateStorageManagerFromResponse: (resp) ->
-    @internalObject.parse(resp)
+    attributes = @internalObject.parse(resp)
+    # @externalObject.set(attributes)
 
   _updateObjects: (object, data) ->
     if _.isArray(data) && data.length == 1
       data = data[0]
-    
+
     if data instanceof Backbone.Model
       data = data.attributes
 

--- a/vendor/assets/javascripts/brainstem/loaders/model-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/model-loader.coffee
@@ -31,9 +31,12 @@ class Brainstem.ModelLoader extends Brainstem.AbstractLoader
 
   _createObjects: ->
     id = @loadOptions.only[0]
+    storage = @storageManager.storage(@_getCollectionName())
+    model = @loadOptions.model
 
-    @internalObject = @storageManager.storage(@_getCollectionName()).get(id) ||
-                      @storageManager.createNewModel(@loadOptions.name, id: id)
+    storage.add(model, remove: false) if model
+
+    @internalObject = model || storage.get(id) || @storageManager.createNewModel(@loadOptions.name, id: id)
     @externalObject = @internalObject
 
   _updateStorageManagerFromResponse: (resp) ->

--- a/vendor/assets/javascripts/brainstem/loaders/model-loader.coffee
+++ b/vendor/assets/javascripts/brainstem/loaders/model-loader.coffee
@@ -36,12 +36,11 @@ class Brainstem.ModelLoader extends Brainstem.AbstractLoader
 
     storage.add(model, remove: false) if model && model.id
 
-    @internalObject = storage.get(id) || @storageManager.createNewModel(@loadOptions.name, id: id)
-    @externalObject = model || @internalObject
+    @internalObject =
+    @externalObject = storage.get(id) || @storageManager.createNewModel(@loadOptions.name, id: id)
 
   _updateStorageManagerFromResponse: (resp) ->
     attributes = @internalObject.parse(resp)
-    # @externalObject.set(attributes)
 
   _updateObjects: (object, data) ->
     if _.isArray(data) && data.length == 1


### PR DESCRIPTION
Fetching a newly instantiated model now results in the new model reference being cached in the storage manager. This allows the reference from instantiation to be used as a canonical reference to the model.

Fixes #71 

Before:

```javascript
var newModel = new Brainstem.Model();

model.fetch().done(function (model) {
  console.log(model.attributes);
  // fetched attributes

  console.log(newModel.attributes);
  // {}

  console.log(model === newModel);
  // false
});
```

After:

```javascript
var newModel = new Brainstem.Model();

model.fetch().done(function (model) {
  console.log(model.attributes);
  // fetched attributes

  console.log(newModel.attributes);
  // fetched attributes

  console.log(model === newModel);
  // true
});
```