### PR TITLE
Fix BackboneFactory global pollution

### DIFF
--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -1,3 +1,5 @@
+_ = require 'underscore'
+$ = require 'jquery'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
 

--- a/spec/loaders/collection-loader-spec.coffee
+++ b/spec/loaders/collection-loader-spec.coffee
@@ -1,3 +1,5 @@
+$ = require 'jquery'
+_ = require 'underscore'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
 StorageManager = require '../../src/storage-manager'

--- a/spec/loaders/model-loader-spec.coffee
+++ b/spec/loaders/model-loader-spec.coffee
@@ -1,3 +1,5 @@
+$ = require 'jquery'
+_ = require 'underscore'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
 StorageManager = require '../../src/storage-manager'

--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore'
 $ = require 'jquery'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -1,3 +1,6 @@
+Backbone = require 'backbone'
+Backbone.$ = require 'jquery'
+
 Model = require '../src/model'
 
 
@@ -5,7 +8,7 @@ describe "Sync", ->
   ajaxSpy = null
 
   beforeEach ->
-    ajaxSpy = spyOn($, 'ajax')
+    ajaxSpy = spyOn(Backbone.$, 'ajax')
 
   describe "updating models", ->
     it "should use toServerJSON instead of toJSON", ->

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -1,3 +1,4 @@
+$ = require 'jquery'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore'
+$ = require 'jquery'
 Backbone = require 'backbone'
 Backbone.$ = require 'jquery' # TODO remove after upgrading to backbone 1.2+
 inflection = require 'inflection'

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore'
 $ = require 'jquery'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+


### PR DESCRIPTION
Require Underscore and jQuery everwhere. Certain modules were previously relying on Underscore and jQuery from global pollution created by BackboneFactory. Those modules now explicitly require *all* of their dependencies (aka Underscore and jQuery)