### PR TITLE
Remove Babel dependency from Gulpfile, target NodeJS 6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5.1.1"
+  - "6.2.2"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,20 +1,20 @@
-import gulp from 'gulp';
-import util from 'gulp-util';
-import minimist from 'minimist';
-import rename from 'gulp-rename';
-import replace from 'gulp-replace';
-import download from 'gulp-download';
-import path from 'path';
-import del from 'del';
-import coffee from 'gulp-coffee';
-import stream from 'vinyl-source-stream';
-import browserify from 'browserify';
-import coffeeify from 'coffeeify';
-import shim from 'browserify-shim';
-import coffeelint from 'gulp-coffeelint';
-import { Server as Karma } from 'karma';
+const gulp = require('gulp');
+const util = require('gulp-util');
+const minimist = require('minimist');
+const rename = require('gulp-rename');
+const replace = require('gulp-replace');
+const download = require('gulp-download');
+const path = require('path');
+const del = require('del');
+const coffee = require('gulp-coffee');
+const stream = require('vinyl-source-stream');
+const browserify = require('browserify');
+const coffeeify = require('coffeeify');
+const shim = require('browserify-shim');
+const coffeelint = require('gulp-coffeelint');
+const { Server: Karma } = require('karma');
 
-import { version, standalone, filename } from './package';
+const { version, standalone, filename } = require('./package');
 
 
 const source = './src/**/*.coffee';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": "https://github.com/mavenlink/brainstem-js",
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
     "underscore": "1.4.4"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-core": "^6.7.2",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-stage-0": "^6.5.0",
     "backbone-factory": "https://github.com/jrolfs/Backbone-Factory.git#master",
     "browserify": "^13.0.0",
     "browserify-shim": "^3.8.12",
@@ -64,6 +60,6 @@
     "backbone": "global:Backbone"
   },
   "engines": {
-    "node": ">=5.1.1"
+    "node": ">=6.0"
   }
 }


### PR DESCRIPTION
Since Node 6+ supports everything except for ES6 modules it makes sense to remove the Babel dependency here and simply use CommonJS' `require` instead of `import`.