### PR TITLE
Collections have `firstFetchOptions: {}`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "standalone": "Brainstem",
   "version": "0.4.13",
   "author": {
-    "name": "Mavenlink",
-    "email": "dev@mavenlink.com"
+    "name": "Juan Carlos Medina",
+    "email": "juanca.med@gmail.com"
   },
   "license": "MIT",
   "main": "lib/brainstem.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.13",
+  "version": "0.4.14-a",
   "author": {
     "name": "Juan Carlos Medina",
     "email": "juanca.med@gmail.com"

--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -49,6 +49,10 @@ describe 'Brainstem Storage Manager', ->
       timeEntry.collection.remove(timeEntry)
       expect(timeEntry.invalidateCache).toHaveBeenCalled()
 
+    it 'initializes firstFetchOptions is an empty object', ->
+      manager.addCollection 'time_entries', TimeEntries
+      expect(manager.storage('time_entries').firstFetchOptions).toEqual({})
+
   describe "reset", ->
     it "should clear all storage and sort lengths", ->
       buildAndCacheTask()

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -62,7 +62,7 @@ class _StorageManager
   # Add a collection to the StorageManager.  All collections that will be loaded or used in associations must be added.
   #    manager.addCollection "time_entries", TimeEntries
   addCollection: (name, collectionClass) ->
-    collection = new collectionClass()
+    collection = new collectionClass([], {})
 
     collection.on 'remove', (model) ->
       model.invalidateCache()


### PR DESCRIPTION
Ensure collections within the storage manager always have an empty first fetch options object

This ensures pollution cannot happen in case one of these collections is needed (an example would be to avoid initializing a new collection -- such as [brainstem-redux](https://github.com/mavenlink/brainstem-redux))

@naganowl 