### PR TITLE
Add workaround for global singleton

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,6 +43,5 @@ module.exports = function (config) {
       watch: true,
       debug: true
     }
-
   });
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.14",
+  "version": "0.4.15-a",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "standalone": "Brainstem",
   "version": "0.4.14",
   "author": {
-    "name": "Juan Carlos Medina",
-    "email": "juanca.med@gmail.com"
+    "name": "Mavenlink",
+    "email": "dev@mavenlink.com"
   },
   "license": "MIT",
   "main": "lib/brainstem.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.15-a",
+  "version": "0.4.15",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/spec/singleton-spec.coffee
+++ b/spec/singleton-spec.coffee
@@ -1,0 +1,7 @@
+StorageManager = require '../src/storage-manager'
+
+
+describe 'Singleton#get without window.base.data', ->
+  it 'uses a cached references', ->
+    cachedStorageManager = StorageManager.get()
+    expect(StorageManager.get()).toBe(cachedStorageManager)

--- a/spec/singleton-window-spec.coffee
+++ b/spec/singleton-window-spec.coffee
@@ -1,19 +1,19 @@
-# StorageManager = require '../src/storage-manager'
-#
-# # This spec file cannot be included with other specs because it requires a pristine
-# # StorageManager singleton instance. Instead, ensure this works by commenting it in
-# # and running it by itself
-#
-# describe 'Singleton#get with window.base.data', ->
-#   stubbedStorageManager = null
-#
-#   beforeAll ->
-#     stubbedStorageManager = {
-#       addCollection: ->
-#       restore: ->
-#     }
-#
-#     window.base = { data: stubbedStorageManager }
-#
-#   fit 'uses the window.base.data reference', ->
-#     expect(StorageManager.get()).toBe(stubbedStorageManager)
+StorageManager = require '../src/storage-manager'
+
+# This spec file cannot be included with other specs because it requires a pristine
+# StorageManager singleton instance. Instead, ensure this works by unpending it and
+# focusing.
+
+xdescribe 'Singleton#get with window.base.data', ->
+  stubbedStorageManager = null
+
+  beforeAll ->
+    stubbedStorageManager = {
+      addCollection: ->
+      restore: ->
+    }
+
+    window.base = { data: stubbedStorageManager }
+
+  it 'uses the window.base.data reference', ->
+    expect(StorageManager.get()).toBe(stubbedStorageManager)

--- a/spec/singleton-window-spec.coffee
+++ b/spec/singleton-window-spec.coffee
@@ -1,0 +1,19 @@
+# StorageManager = require '../src/storage-manager'
+#
+# # This spec file cannot be included with other specs because it requires a pristine
+# # StorageManager singleton instance. Instead, ensure this works by commenting it in
+# # and running it by itself
+#
+# describe 'Singleton#get with window.base.data', ->
+#   stubbedStorageManager = null
+#
+#   beforeAll ->
+#     stubbedStorageManager = {
+#       addCollection: ->
+#       restore: ->
+#     }
+#
+#     window.base = { data: stubbedStorageManager }
+#
+#   fit 'uses the window.base.data reference', ->
+#     expect(StorageManager.get()).toBe(stubbedStorageManager)

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -229,7 +229,7 @@ class StorageManager
   instance = null
 
   @get: ->
-    instance ?= new _StorageManager(arguments)
+    instance ?= window.base?.data ? new _StorageManager(arguments)
 
 
 module.exports = StorageManager


### PR DESCRIPTION
This is a transitionary bit of code:

- Useful when migrating a codebase from globals to JavaScript modules
- Useful in testing environments which rely on globals