### PR TITLE
Parse timestamps only if the attribute has _at or date in the name.

### DIFF
--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -296,6 +296,37 @@ describe 'Model', ->
       expect(storageManager.storage('users').get(5).attributes).toEqual(response.users[5])
       expect(storageManager.storage('users').get(6).attributes).toEqual(response.users[6])
 
+    context 'when attributes are timestamp like', ->
+      parsedAttrs = null
+
+      context 'with a key ending in _at', ->
+        beforeEach ->
+          parsedAttrs = model.parse updated_at: '2017-02-03T16:41:12+00:00'
+
+        it "parse the date into a timestamp number", ->
+          expect(parsedAttrs.updated_at).toEqual(1486140072000)
+
+      context 'with a key containing _at', ->
+        beforeEach ->
+          parsedAttrs = model.parse thing_at_noon: '2017-02-03T16:41:12+00:00'
+
+        it "keeps the value as is", ->
+          expect(parsedAttrs.thing_at_noon).toEqual('2017-02-03T16:41:12+00:00')
+
+      context 'with a key containing date', ->
+        beforeEach ->
+          parsedAttrs = model.parse my_date_thing: '2017-02-03T16:41:12+00:00'
+
+        it "parse the date into a timestamp number", ->
+          expect(parsedAttrs.my_date_thing).toEqual(1486140072000)
+
+      context 'with a generic key', ->
+        beforeEach ->
+          parsedAttrs = model.parse value: '2017-02-03T16:41:12+00:00'
+
+        it "keeps the value as is", ->
+          expect(parsedAttrs.value).toEqual('2017-02-03T16:41:12+00:00')
+
     describe 'adding new models to the storage manager', ->
       context 'there is an ID on the model already', ->
         # usually happens when fetching an existing model and not using StorageManager#loadModel

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -8,6 +8,9 @@ Utils = require './utils'
 StorageManager = require './storage-manager'
 
 
+isDateAttr = (key) ->
+  key.indexOf('date') > -1 || /_at$/.test(key)
+
 class Model extends Backbone.Model
 
   #
@@ -52,7 +55,7 @@ class Model extends Backbone.Model
   @parse: (modelObject) ->
     for k,v of modelObject
       # Date.parse will parse ISO 8601 in ECMAScript 5, but we include a shim for now
-      if /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}[-+]\d{2}:\d{2}$/.test(v)
+      if isDateAttr(k) && /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}[-+]\d{2}:\d{2}$/.test(v)
         modelObject[k] = Date.parse(v)
     return modelObject
 


### PR DESCRIPTION
Only parse timestamps when the attribute has an '_at' in the name or 'date' in the name. 

This is to solve the bug where normal attributes that should be saved as timestamps like this `2017-02-03T16:41:12+00:00` are unintentionally being parsed into integer timestamps. In this example we want to save the original string value and this is not a date field. 

Signed-off-by: Bobby Brown <bobby@mavenlink.com>
https://www.pivotaltracker.com/story/show/139446509