### PR TITLE
Cleanup references on destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.17-a",
+  "version": "0.4.17",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.16",
+  "version": "0.4.17-a",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -995,6 +995,12 @@ describe 'Model', ->
 
         expect(task.get('project_id')).toBeUndefined()
 
+      it 'should not remove associations to other objects', ->
+        task = buildAndCacheTask(id: 27, project_id: buildAndCacheProject(id: 34).id)
+
+        project.destroy()
+        expect(task.get('project_id')).toEqual('34')
+
     context 'when the deleted object is referenced in a has-many relationship', ->
       it 'should remove the reference to the deleted object', ->
         childTaskToDelete = buildAndCacheTask(id:103 , position: 3, updated_at: 845785, parent_task_id: 7)

--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -998,7 +998,11 @@ describe 'Model', ->
     context 'when the deleted object is referenced in a has-many relationship', ->
       it 'should remove the reference to the deleted object', ->
         childTaskToDelete = buildAndCacheTask(id:103 , position: 3, updated_at: 845785, parent_task_id: 7)
-        survivingChildTaskIds = _.pluck([ buildAndCacheTask(id:77 , position: 2, updated_at: 995785, parent_task_id: 7), buildAndCacheTask(id:99 , position: 1, updated_at: 635785, parent_task_id: 7)], 'id')
+        survivingChildTaskIds = _.pluck(
+          [
+            buildAndCacheTask(id:77 , position: 2, updated_at: 995785, parent_task_id: 7)
+            buildAndCacheTask(id:99 , position: 1, updated_at: 635785, parent_task_id: 7)
+          ], 'id')
 
         task = buildAndCacheTask(id: 7, sub_task_ids: [103, 77, 99])
 
@@ -1009,12 +1013,11 @@ describe 'Model', ->
 
     context 'using wait option', ->
       it 'should remove the associations on success of the delete and returns a promise', ->
-        deferred = $.Deferred()
-        spyOn(Backbone.Model.prototype, 'destroy').and.returnValue(deferred)
         result = project.destroy(wait: true)
 
         expect(task.get('project').id).toEqual(project.id)
 
-        deferred.resolve()
+        project.trigger('destroy')
+
         expect(task.get('project_id')).toBeUndefined()
         expect(result.done).toBeDefined()

--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -1006,3 +1006,15 @@ describe 'Model', ->
 
         expect(task.get('sub_task_ids')).toEqual(survivingChildTaskIds)
         expect(task.get('sub_tasks').pluck('id')).toEqual(survivingChildTaskIds)
+
+    context 'using wait option', ->
+      it 'should remove the associations on success of the delete and returns a promise', ->
+        deferred = $.Deferred()
+        spyOn(Backbone.Model.prototype, 'destroy').and.returnValue(deferred)
+        result = project.destroy(wait: true)
+
+        expect(task.get('project').id).toEqual(project.id)
+
+        deferred.resolve()
+        expect(task.get('project_id')).toBeUndefined()
+        expect(result.done).toBeDefined()

--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -982,20 +982,21 @@ describe 'Model', ->
       project = buildAndCacheProject(id: 10, task_ids: [task.id])
 
     it 'should delegate to Backbone.Model#destroy', ->
+      options = { an: 'option' }
       destroySpy = spyOn(Backbone.Model.prototype, 'destroy')
 
-      task.destroy()
+      task.destroy(options)
 
-      expect(destroySpy).toHaveBeenCalled()
+      expect(destroySpy).toHaveBeenCalledWith(options)
 
     context 'when deleted object is referenced in a belongs-to relationship', ->
-      it 'should set associated reference to undefined', ->
+      it 'should set the associated reference to undefined', ->
         project.destroy()
 
         expect(task.get('project_id')).toBeUndefined()
 
     context 'when the deleted object is referenced in a has-many relationship', ->
-      it 'should set remove the reference to the deleted object', ->
+      it 'should remove the reference to the deleted object', ->
         childTaskToDelete = buildAndCacheTask(id:103 , position: 3, updated_at: 845785, parent_task_id: 7)
         survivingChildTaskIds = _.pluck([ buildAndCacheTask(id:77 , position: 2, updated_at: 995785, parent_task_id: 7), buildAndCacheTask(id:99 , position: 1, updated_at: 635785, parent_task_id: 7)], 'id')
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -179,7 +179,9 @@ class Model extends Backbone.Model
               model.set(associationKey, _.without(model.get(associationKey), @id))
             , this
           else if @_collectionBelongsTo(associator)
-            collection.storage.invoke('unset', associationKey)
+            collection.storage.each (model) ->
+              model.unset(associationKey) if model.get(associationKey) == @id
+            , this
         , this
       , this
 

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -169,6 +169,19 @@ class Model extends Backbone.Model
       )
       .promise(options.returnValues.jqXhr)
 
+  destroy: (options) ->
+    for collectionName, collection of @storageManager.collections
+      for reference, modelName of collection.modelKlass.associations
+        associationKey = collection.modelKlass.associationDetails(reference).key
+        if _.isArray(modelName) && _.find(modelName, (m) => inflection.singularize(m) == @className())
+          collection.storage.each (model) =>
+            model.set(associationKey, _.without(model.get(associationKey), @id))
+        else if !_.isArray(modelName) && inflection.singularize(modelName) == @className()
+          collection.storage.each (model) =>
+            model.unset(associationKey)
+
+    super(options)
+
   # Handle create and update responses with JSON root keys
   parse: (resp, xhr) ->
     @updateStorageManager(resp)


### PR DESCRIPTION
Partially addresses this issue: https://github.com/mavenlink/brainstem-js/issues/76

References to associations aren't cleaned up when a model is destroyed. This PR does this without making any extra requests. 