### PR TITLE
Bump to 0.4.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"


### PR DESCRIPTION
Seems like `0.4.19` was broken and there isn't anyway to override it.

See https://github.com/npm/npm/issues/10556 for more details.