### PR TITLE
Fix the error message to include the collection name

### DIFF
--- a/vendor/assets/javascripts/brainstem.js
+++ b/vendor/assets/javascripts/brainstem.js
@@ -2475,7 +2475,7 @@ Model = (function(superClass) {
           }
           model = this.storageManager.storage(collectionName).get(pointer);
           if (!model && !options.silent) {
-            Utils.throwError("Unable to find " + field + " with id " + id + " in our cached {details.collectionName} collection. We know about " + (this.storageManager.storage(details.collectionName).pluck('id').join(', ')));
+            Utils.throwError("Unable to find " + field + " with id " + id + " in our cached " + details.collectionName + " collection. We know about " + (this.storageManager.storage(details.collectionName).pluck('id').join(', ')));
           }
           return model;
         }


### PR DESCRIPTION
A bug from bigmaven left a console error of

```
Uncaught Error: Unable to find default_role with id 1231231 in our cached {details.collectionName} collection. We know about 123123, 123123, .... , fragment: pending
```

This PR cleans up that error message to actually output the collection name.