### PR TITLE
Fix the error message to include the collection name

### DIFF
--- a/lib/brainstem/js/version.rb
+++ b/lib/brainstem/js/version.rb
@@ -1,5 +1,5 @@
 module Brainstem
   module Js
-    VERSION = "0.4.8"
+    VERSION = "0.4.9"
   end
 end

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -106,7 +106,7 @@ class Model extends Backbone.Model
 
           if not model && not options.silent
             Utils.throwError("""
-              Unable to find #{field} with id #{id} in our cached {details.collectionName} collection.
+              Unable to find #{field} with id #{id} in our cached #{details.collectionName} collection.
               We know about #{@storageManager.storage(details.collectionName).pluck('id').join(', ')}
             """)
 


### PR DESCRIPTION
A bug from bigmaven left a console error of

```
Uncaught Error: Unable to find default_role with id 1231231 in our cached {details.collectionName} collection. We know about 123123, 123123, .... , fragment: pending
```

This PR cleans up that error message to actually output the collection name.

Compiled with `gulp build-gem`