### PR TITLE
Refactor getWithAssocation to getWithAssociation

### DIFF
--- a/spec/collection-spec.coffee
+++ b/spec/collection-spec.coffee
@@ -88,10 +88,10 @@ describe 'Collection', ->
         collection = storageManager.createNewCollection 'tasks'
         expect(collection.getServerCount()).toBeUndefined()
 
-  describe '#getWithAssocation', ->
+  describe '#getWithAssociation', ->
     it 'defaults to the regular get', ->
       spyOn(collection, 'get')
-      collection.getWithAssocation(10)
+      collection.getWithAssociation(10)
       expect(collection.get).toHaveBeenCalledWith(10)
 
   describe '#fetch', ->

--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -70,7 +70,7 @@ module.exports = class Collection extends Backbone.Collection
   getServerCount: ->
     @_getCacheObject()?.count
 
-  getWithAssocation: (id) ->
+  getWithAssociation: (id) ->
     @get(id)
 
 

--- a/vendor/assets/javascripts/brainstem.js
+++ b/vendor/assets/javascripts/brainstem.js
@@ -1167,7 +1167,7 @@ module.exports = Collection = (function(superClass) {
     return (ref = this._getCacheObject()) != null ? ref.count : void 0;
   };
 
-  Collection.prototype.getWithAssocation = function(id) {
+  Collection.prototype.getWithAssociation = function(id) {
     return this.get(id);
   };
 


### PR DESCRIPTION
(non-user facing)

Fix method typo. Will need corresponding PR to `mavenlink-js` even though method is not used in bigmaven.