### PR TITLE
Cache invalidation associations and blacklist

### DIFF
--- a/spec/helpers/models/task.coffee
+++ b/spec/helpers/models/task.coffee
@@ -12,5 +12,4 @@ class Task extends Model
     sub_tasks: ["tasks"]
     parent: "tasks"
 
-
 module.exports = Task

--- a/spec/helpers/models/time-entry.coffee
+++ b/spec/helpers/models/time-entry.coffee
@@ -11,5 +11,7 @@ class TimeEntry extends Model
     task: "tasks"
     user: "users"
 
+  defaultJSONBlacklist: ->
+    ['calculated_attribute']
 
 module.exports = TimeEntry

--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -1006,10 +1006,26 @@ describe 'Brainstem Storage Manager', ->
           expect(Object.keys(cacheMap).length).toEqual(1)
 
       describe 'existing model updated', ->
-        it 'wipes out the cache', ->
-          @collection.first().set('title', 'money')
-          cacheMap = manager.getCollectionDetails('time_entries').cache
-          expect(Object.keys(cacheMap).length).toEqual(0)
+        describe 'modified blacklisted attribute', ->
+          it 'does nothing to the cache', ->
+            blacklistedAttribute = @collection.first().defaultJSONBlacklist()[1]
+            @collection.first().set(blacklistedAttribute, 'nothing changes')
+            cacheMap = manager.getCollectionDetails('time_entries').cache
+            expect(Object.keys(cacheMap).length).toEqual(1)
+
+        describe 'modifed whitelisted attribute', ->
+          describe 'same value', ->
+            it 'does nothing to the cache', ->
+              @collection.first().set('title', 'money', silent: true)
+              @collection.first().set('title', 'money')
+              cacheMap = manager.getCollectionDetails('time_entries').cache
+              expect(Object.keys(cacheMap).length).toEqual(1)
+
+          describe 'new value', ->
+            it 'wipes out the cache', ->
+              @collection.first().set('title', 'money')
+              cacheMap = manager.getCollectionDetails('time_entries').cache
+              expect(Object.keys(cacheMap).length).toEqual(0)
 
     describe 'existing model destroyed', ->
       it 'wipes out the cache', ->

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -206,7 +206,7 @@ class _StorageManager
   _shouldInvalidateCache: (model) ->
     return false if !model
     return false if model.isNew()
-    return true if Object.keys(model.changed).length is 0 # destroyed
+    return true unless model.hasChanged() # destroyed
 
     blacklist = model.defaultJSONBlacklist() || []
     for attribute of model.changed when attribute not in blacklist

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -206,7 +206,13 @@ class _StorageManager
   _shouldInvalidateCache: (model) ->
     return false if !model
     return false if model.isNew()
-    return true
+    return true if Object.keys(model.changed).length is 0 # destroyed
+
+    blacklist = model.defaultJSONBlacklist() || []
+    for attribute of model.changed when attribute not in blacklist
+      return true
+
+    return false
 
   _invalidateCache: (model) =>
     @collections[model.brainstemKey].cache = {} if @_shouldInvalidateCache(model)

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -61,9 +61,7 @@ class _StorageManager
     collection.on 'remove', (model) ->
       model.invalidateCache()
 
-    collection.on 'destroy change', (model) =>
-      return unless model
-      @_invalidateCache(model.brainstemKey) unless model.isNew()
+    collection.on 'destroy change', @_invalidateCache
 
     @collections[name] =
       klass: collectionClass
@@ -205,8 +203,13 @@ class _StorageManager
   #
   # Private
 
-  _invalidateCache: (name) ->
-    @collections[name].cache = {}
+  _shouldInvalidateCache: (model) ->
+    return false if !model
+    return false if model.isNew()
+    return true
+
+  _invalidateCache: (model) =>
+    @collections[model.brainstemKey].cache = {} if @_shouldInvalidateCache(model)
 
   _checkPageSettings: (options) ->
     if options.limit? && options.limit != '' && options.offset? && options.offset != ''


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? -->

Modifies existing control flow to be more restrictive.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Blacklist attributes are never sent to the server (hence, blacklisted). Because the server is not being updated by these modified values, the changes theoretically do not impact server results. The cache can still be respected on subsequent fetches. Example of blacklist attributes: associations, calculated fields.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Integration tests showcase impact on caches when setting values on existing models. 

<!-- Requirement for Mavenlink engineers: Provide links to any related product requirements and builds using this changeset (e.g. brainstem-redux, mavenlink-js, mavenlink/mavenlink. -->

- [ ] https://github.com/mavenlink/mavenlink/pull/9305