### PR TITLE
Revert cache invalidation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.4.32",
+  "version": "0.4.34",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -994,32 +994,3 @@ describe 'Brainstem Storage Manager', ->
         expect(successHandler).not.toHaveBeenCalled()
         expect(errorHandler).toHaveBeenCalled()
         expect(errorHandler.calls.count()).toEqual(1)
-
-  describe 'cache invalidation', ->
-    beforeEach ->
-      timeEntries = [buildTimeEntry(), buildTimeEntry()]
-      respondWith server, '/api/time_entries?per_page=20&page=1', resultsFrom: 'time_entries', data: { time_entries: timeEntries }
-      @collection = manager.loadCollection 'time_entries'
-      server.respond()
-      cacheMap = manager.getCollectionDetails('time_entries').cache
-      expect(Object.keys(cacheMap).length).toEqual(1)
-
-    describe 'model changes', ->
-      describe 'new model updated', ->
-        it 'does nothing to the cache', ->
-          @collection.add(buildTimeEntry())
-          @collection.last().set('title', 'money')
-          cacheMap = manager.getCollectionDetails('time_entries').cache
-          expect(Object.keys(cacheMap).length).toEqual(1)
-
-      describe 'existing model updated', ->
-        it 'wipes out the cache', ->
-          @collection.first().set('title', 'money')
-          cacheMap = manager.getCollectionDetails('time_entries').cache
-          expect(Object.keys(cacheMap).length).toEqual(0)
-
-    describe 'existing model destroyed', ->
-      it 'wipes out the cache', ->
-        @collection.first().destroy()
-        cacheMap = manager.getCollectionDetails('time_entries').cache
-        expect(Object.keys(cacheMap).length).toEqual(0)

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -61,10 +61,6 @@ class _StorageManager
     collection.on 'remove', (model) ->
       model.invalidateCache()
 
-    collection.on 'destroy change', (model) =>
-      return unless model
-      @_invalidateCache(model.brainstemKey) unless model.isNew()
-
     @collections[name] =
       klass: collectionClass
       modelKlass: collectionClass.prototype.model
@@ -204,9 +200,6 @@ class _StorageManager
 
   #
   # Private
-
-  _invalidateCache: (name) ->
-    @collections[name].cache = {}
 
   _checkPageSettings: (options) ->
     if options.limit? && options.limit != '' && options.offset? && options.offset != ''


### PR DESCRIPTION
Backgrid integrations in breaking because they assume the cache always exists. This is a bad integration since the UI should not care about the cache whatsoever. Alas, we have to revert to preserve existing features. If we want to improve the cache invalidation logic, we will want to remove any access to the cache first (which will identify these issues). And then bust the cache whenever we feel like it.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? -->

No.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Backgrid paginator code in our Collection class is broken when the cache is busted. The cache should really be private and only used by the storage manager. :( 

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- Requirement for Mavenlink engineers: Provide links to any related product requirements and builds using this changeset (e.g. brainstem-redux, mavenlink-js, mavenlink/mavenlink. -->
