### PR TITLE
Trigger custom collection updated event after updating collection 

### DIFF
--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -125,18 +125,23 @@ module.exports = class Collection extends Backbone.Collection
     @loaded = state
     @trigger 'loaded', this if state && options.trigger
 
-  update: (models) ->
+  update: (models, brainstemKey) ->
     models = models.models if models.models?
+    backboneModels = []
     for model in models
       model = this.model.parse(model) if this.model.parse?
       backboneModel = @_prepareModel(model, blacklist: [])
       if backboneModel
         if modelInCollection = @get(backboneModel.id)
-          modelInCollection.set backboneModel.attributes
+          backboneModels.push(modelInCollection.set(backboneModel.attributes))
         else
-          @add backboneModel
+          backboneModels.push(backboneModel)
       else
         Utils.warn 'Unable to update collection with invalid model', model
+
+    @set(backboneModels)
+    @trigger('collection_updated', this, brainstemKey);
+    backboneModels
 
   reload: (options) ->
     @storageManager.reset()

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -73,7 +73,7 @@ class CollectionLoader extends AbstractLoader
       keys.push(@loadOptions.name)
 
     for underscoredModelName in keys
-      @storageManager.storage(underscoredModelName).update _(resp[underscoredModelName]).values()
+      @storageManager.storage(underscoredModelName).update(_(resp[underscoredModelName]).values(), underscoredModelName)
 
     cachedData =
       count: resp.count


### PR DESCRIPTION
WIP

 - adding each individual model one at a time causes an add event to get fired for each model
 - setting it in one pass gets rid of some unnecessary backbone events
 - update collection takes in the brainstemKey and uses it in the custom event

Signed-off-by: Ellie Day <eday@mavenlink.com>

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- Requirement for Mavenlink engineers: Provide links to any related product requirements and builds using this changeset (e.g. brainstem-redux, mavenlink-js, mavenlink/mavenlink. -->
