### PR TITLE
Custom XHR header: X-Feature-Name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,4 +127,14 @@ gulp.task('test-watch', (done) => {
   new Karma(config, karmaErrorHandler.bind(done)).start();
 });
 
+gulp.task('test-debug', (done) => {
+  var config = Object.assign({}, karmaConfig, {
+    browsers: ['Chrome'],
+    singleRun: false,
+    autoWatch: true
+  });
+
+  new Karma(config, karmaErrorHandler.bind(done)).start();
+});
+
 gulp.task('ci', ['coffeelint', 'test-ci']);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "prepublish": "gulp build-module",
     "test": "gulp test",
+    "test:debug": "gulp test-debug",
     "test:watch": "gulp test-watch"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.1-a",
+  "version": "0.5.1-b",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.0",
+  "version": "0.5.1-a",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.1-b",
+  "version": "0.5.1",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -462,7 +462,9 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
 
     beforeEach ->
       loader = createLoader()
-      opts = _.extend(defaultLoadOptions(), cache: false)
+      opts = _.extend defaultLoadOptions(),
+        cache: false
+        feature_name: 'a-feature'
       opts.include = fakeNestedInclude
 
       loader.setup(opts)
@@ -478,6 +480,15 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
 
       for call in calls.all()
         expect(call.args[1].cache).toBe(false)
+
+    it 'respects "feature_name" option in nested includes', ->
+      spyOn(loader.storageManager, 'loadObject')
+      loader._loadAdditionalIncludes()
+      calls = loader.storageManager.loadObject.calls
+      expect(calls.count()).toBeGreaterThan(0)
+
+      for call in calls.all()
+        expect(call.args[1].feature_name).toBe('a-feature')
 
     it 'creates a request for each additional include and calls #_onLoadingCompleted when they all are done', ->
       promises = []

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -473,9 +473,11 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
     it 'respects "cache" option in nested includes', ->
       spyOn(loader.storageManager, 'loadObject')
       loader._loadAdditionalIncludes()
+      calls = loader.storageManager.loadObject.calls
+      expect(calls.count()).toBeGreaterThan(0)
 
-      for call in loader.storageManager.loadObject.calls
-        expect(call.args[1].cache).toBeFalsey
+      for call in calls.all()
+        expect(call.args[1].cache).toBe(false)
 
     it 'creates a request for each additional include and calls #_onLoadingCompleted when they all are done', ->
       promises = []

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -12,13 +12,26 @@ describe "Sync", ->
     ajaxSpy = spyOn(Backbone.$, 'ajax')
 
   describe 'custom headers', ->
-    it 'sets X-Feature-Name', ->
-      collection = new TimeEntries()
-      jqXhr = collection.fetch(feature_name: 'ima-feature')
-      beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
-      setRequestHeader = jasmine.createSpy('setRequestHeader')
-      beforeSend({ setRequestHeader })
-      expect(setRequestHeader).toHaveBeenCalledWith('X-Feature-Name', 'ima-feature')
+    beforeSend = null
+    collection = null
+    setRequestHeader = null
+
+    describe 'X-Feature-Name', ->
+      beforeEach ->
+        collection = new TimeEntries()
+        setRequestHeader = jasmine.createSpy('setRequestHeader')
+
+      it 'is not undefined', ->
+        jqXhr = collection.fetch()
+        beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
+        beforeSend({ setRequestHeader })
+        expect(setRequestHeader).not.toHaveBeenCalledWith('X-Feature-Name', undefined)
+
+      it 'settable via feature_name', ->
+        jqXhr = collection.fetch(feature_name: 'ima-feature')
+        beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
+        beforeSend({ setRequestHeader })
+        expect(setRequestHeader).toHaveBeenCalledWith('X-Feature-Name', 'ima-feature')
 
   describe "updating models", ->
     it "should use toServerJSON instead of toJSON", ->

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -2,6 +2,7 @@ Backbone = require 'backbone'
 Backbone.$ = require 'jquery'
 
 Model = require '../src/model'
+TimeEntries = require './helpers/models/time-entries.coffee'
 
 
 describe "Sync", ->
@@ -9,6 +10,15 @@ describe "Sync", ->
 
   beforeEach ->
     ajaxSpy = spyOn(Backbone.$, 'ajax')
+
+  describe 'custom headers', ->
+    it 'sets X-Feature-Name', ->
+      collection = new TimeEntries()
+      jqXhr = collection.fetch(feature_name: 'ima-feature')
+      beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
+      setRequestHeader = jasmine.createSpy('setRequestHeader')
+      beforeSend({ setRequestHeader })
+      expect(setRequestHeader).toHaveBeenCalledWith('X-Feature-Name', 'ima-feature')
 
   describe "updating models", ->
     it "should use toServerJSON instead of toJSON", ->

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -316,7 +316,17 @@ class AbstractLoader
     syncOptions.data.search = options.search if options.search
     syncOptions.data.optional_fields = @loadOptions.optionalFields.join(',') if @loadOptions.optionalFields?.length
 
-    blacklist = ['include', 'only', 'order', 'per_page', 'page', 'limit', 'offset', 'search', 'optional_fields']
+    blacklist = [
+      'include'
+      'limit'
+      'offset'
+      'only'
+      'optional_fields'
+      'order'
+      'page'
+      'per_page'
+      'search'
+    ]
     _(syncOptions.data).chain()
       .extend(_(options.filters).omit(blacklist))
       .extend(_(options.params).omit(blacklist))

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -278,6 +278,7 @@ class AbstractLoader
     for association in @additionalIncludes
       loadOptions =
         cache: @loadOptions.cache
+        feature_name: @loadOptions.feature_name
         only: association.ids
         params:
           apply_default_filters: false

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -306,6 +306,7 @@ class AbstractLoader
     options = @loadOptions
     syncOptions =
       data: {}
+      featureName: @loadOptions.feature_name
       parse: true
       error: @_onServerLoadError
       success: @_onServerLoadSuccess
@@ -317,6 +318,7 @@ class AbstractLoader
     syncOptions.data.optional_fields = @loadOptions.optionalFields.join(',') if @loadOptions.optionalFields?.length
 
     blacklist = [
+      'feature_name'
       'include'
       'limit'
       'offset'

--- a/src/sync.coffee
+++ b/src/sync.coffee
@@ -85,9 +85,8 @@ module.exports = (method, model, options) ->
 
   beforeSend = options.beforeSend
   options.beforeSend = (xhr) ->
-    xhr.setRequestHeader 'X-Feature-Name', options.featureName
-    if beforeSend
-      beforeSend.apply this, arguments
+    xhr.setRequestHeader 'X-Feature-Name', options.featureName if options.featureName
+    beforeSend.apply this, arguments if beforeSend
 
   # Make the request, allowing the user to override any Ajax options.
   xhr = options.xhr = Backbone.ajax(_.extend(params, options))

--- a/src/sync.coffee
+++ b/src/sync.coffee
@@ -65,8 +65,7 @@ module.exports = (method, model, options) ->
     beforeSend = options.beforeSend
     options.beforeSend = (xhr) ->
       xhr.setRequestHeader 'X-HTTP-Method-Override', type
-      if beforeSend
-        beforeSend.apply this, arguments
+      beforeSend?.apply this, arguments
 
   # Clear out default data for DELETE requests, fixes a firefox issue where this
   # exception is thrown: JavaScript component does not have a method named: “available”
@@ -86,7 +85,7 @@ module.exports = (method, model, options) ->
   beforeSend = options.beforeSend
   options.beforeSend = (xhr) ->
     xhr.setRequestHeader 'X-Feature-Name', options.featureName if options.featureName
-    beforeSend.apply this, arguments if beforeSend
+    beforeSend?.apply this, arguments
 
   # Make the request, allowing the user to override any Ajax options.
   xhr = options.xhr = Backbone.ajax(_.extend(params, options))

--- a/src/sync.coffee
+++ b/src/sync.coffee
@@ -83,6 +83,12 @@ module.exports = (method, model, options) ->
   if params.type == 'PATCH' && window.ActiveXObject && !(window.external && window.external.msActiveXFilteringEnabled)
     params.xhr = -> new ActiveXObject('Microsoft.XMLHTTP')
 
+  beforeSend = options.beforeSend
+  options.beforeSend = (xhr) ->
+    xhr.setRequestHeader 'X-Feature-Name', options.featureName
+    if beforeSend
+      beforeSend.apply this, arguments
+
   # Make the request, allowing the user to override any Ajax options.
   xhr = options.xhr = Backbone.ajax(_.extend(params, options))
   model.trigger 'request', model, xhr, options


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? -->

This is a minimally impacting feature. It is backwards compatible since it does not affect any existing feature.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is useful when collecting data on server requests. For example, my use case is analytics. I want to see the performance of my features. Each model or collection fetch can always be associated with some feature. Seeing the usage and performance of such fetches is useful!

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Unit test implemented which calls the `beforeSend` option passed into sync. The `jqXhr` object does not expose the internal headers. I will also build this against the bigmaven application.

<!-- Requirement for Mavenlink engineers: Provide links to any related product requirements and builds using this changeset (e.g. brainstem-redux, mavenlink-js, mavenlink/mavenlink. -->
