### PR TITLE
Revert "Custom XHR header: X-Feature-Name"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,14 +127,4 @@ gulp.task('test-watch', (done) => {
   new Karma(config, karmaErrorHandler.bind(done)).start();
 });
 
-gulp.task('test-debug', (done) => {
-  var config = Object.assign({}, karmaConfig, {
-    browsers: ['Chrome'],
-    singleRun: false,
-    autoWatch: true
-  });
-
-  new Karma(config, karmaErrorHandler.bind(done)).start();
-});
-
 gulp.task('ci', ['coffeelint', 'test-ci']);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"
@@ -16,7 +16,6 @@
   "scripts": {
     "prepublish": "gulp build-module",
     "test": "gulp test",
-    "test:debug": "gulp test-debug",
     "test:watch": "gulp test-watch"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -462,9 +462,7 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
 
     beforeEach ->
       loader = createLoader()
-      opts = _.extend defaultLoadOptions(),
-        cache: false
-        feature_name: 'a-feature'
+      opts = _.extend(defaultLoadOptions(), cache: false)
       opts.include = fakeNestedInclude
 
       loader.setup(opts)
@@ -475,20 +473,9 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
     it 'respects "cache" option in nested includes', ->
       spyOn(loader.storageManager, 'loadObject')
       loader._loadAdditionalIncludes()
-      calls = loader.storageManager.loadObject.calls
-      expect(calls.count()).toBeGreaterThan(0)
 
-      for call in calls.all()
-        expect(call.args[1].cache).toBe(false)
-
-    it 'respects "feature_name" option in nested includes', ->
-      spyOn(loader.storageManager, 'loadObject')
-      loader._loadAdditionalIncludes()
-      calls = loader.storageManager.loadObject.calls
-      expect(calls.count()).toBeGreaterThan(0)
-
-      for call in calls.all()
-        expect(call.args[1].feature_name).toBe('a-feature')
+      for call in loader.storageManager.loadObject.calls
+        expect(call.args[1].cache).toBeFalsey
 
     it 'creates a request for each additional include and calls #_onLoadingCompleted when they all are done', ->
       promises = []

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -2,7 +2,6 @@ Backbone = require 'backbone'
 Backbone.$ = require 'jquery'
 
 Model = require '../src/model'
-TimeEntries = require './helpers/models/time-entries.coffee'
 
 
 describe "Sync", ->
@@ -10,28 +9,6 @@ describe "Sync", ->
 
   beforeEach ->
     ajaxSpy = spyOn(Backbone.$, 'ajax')
-
-  describe 'custom headers', ->
-    beforeSend = null
-    collection = null
-    setRequestHeader = null
-
-    describe 'X-Feature-Name', ->
-      beforeEach ->
-        collection = new TimeEntries()
-        setRequestHeader = jasmine.createSpy('setRequestHeader')
-
-      it 'is not undefined', ->
-        jqXhr = collection.fetch()
-        beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
-        beforeSend({ setRequestHeader })
-        expect(setRequestHeader).not.toHaveBeenCalledWith('X-Feature-Name', undefined)
-
-      it 'settable via feature_name', ->
-        jqXhr = collection.fetch(feature_name: 'ima-feature')
-        beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
-        beforeSend({ setRequestHeader })
-        expect(setRequestHeader).toHaveBeenCalledWith('X-Feature-Name', 'ima-feature')
 
   describe "updating models", ->
     it "should use toServerJSON instead of toJSON", ->

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -278,7 +278,6 @@ class AbstractLoader
     for association in @additionalIncludes
       loadOptions =
         cache: @loadOptions.cache
-        feature_name: @loadOptions.feature_name
         only: association.ids
         params:
           apply_default_filters: false
@@ -307,7 +306,6 @@ class AbstractLoader
     options = @loadOptions
     syncOptions =
       data: {}
-      featureName: @loadOptions.feature_name
       parse: true
       error: @_onServerLoadError
       success: @_onServerLoadSuccess
@@ -318,18 +316,7 @@ class AbstractLoader
     syncOptions.data.search = options.search if options.search
     syncOptions.data.optional_fields = @loadOptions.optionalFields.join(',') if @loadOptions.optionalFields?.length
 
-    blacklist = [
-      'feature_name'
-      'include'
-      'limit'
-      'offset'
-      'only'
-      'optional_fields'
-      'order'
-      'page'
-      'per_page'
-      'search'
-    ]
+    blacklist = ['include', 'only', 'order', 'per_page', 'page', 'limit', 'offset', 'search', 'optional_fields']
     _(syncOptions.data).chain()
       .extend(_(options.filters).omit(blacklist))
       .extend(_(options.params).omit(blacklist))

--- a/src/sync.coffee
+++ b/src/sync.coffee
@@ -65,7 +65,8 @@ module.exports = (method, model, options) ->
     beforeSend = options.beforeSend
     options.beforeSend = (xhr) ->
       xhr.setRequestHeader 'X-HTTP-Method-Override', type
-      beforeSend?.apply this, arguments
+      if beforeSend
+        beforeSend.apply this, arguments
 
   # Clear out default data for DELETE requests, fixes a firefox issue where this
   # exception is thrown: JavaScript component does not have a method named: “available”
@@ -81,11 +82,6 @@ module.exports = (method, model, options) ->
   # for XHR instead. Remove this line when jQuery supports `PATCH` on IE8.
   if params.type == 'PATCH' && window.ActiveXObject && !(window.external && window.external.msActiveXFilteringEnabled)
     params.xhr = -> new ActiveXObject('Microsoft.XMLHTTP')
-
-  beforeSend = options.beforeSend
-  options.beforeSend = (xhr) ->
-    xhr.setRequestHeader 'X-Feature-Name', options.featureName if options.featureName
-    beforeSend?.apply this, arguments
 
   # Make the request, allowing the user to override any Ajax options.
   xhr = options.xhr = Backbone.ajax(_.extend(params, options))


### PR DESCRIPTION
Reverts mavenlink/brainstem-js#125

@juanca, FYI, the `feature_name` key conflicts with some filters in use in the app. Turns out that the "blacklist" keys get explicitly removed from the provided filters.