### PR TITLE
Nest custom headers in `headers` key

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.2-a",
+  "version": "0.5.2",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.1",
+  "version": "0.5.2-a",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.2",
+  "version": "0.5.3-0",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.3-0",
+  "version": "0.5.3-a",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.3-a",
+  "version": "0.5.3",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -536,6 +536,13 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
 
       expect(getSyncOptions(loader, opts).data.include).toEqual('task,time_entries')
 
+    it 'sets the headers', ->
+      opts.headers = {
+        'X-Custom-Header': 'custom-header-value',
+      }
+
+      expect(getSyncOptions(loader, opts).headers['X-Custom-Header']).toEqual('custom-header-value')
+
     describe 'data.only', ->
       context 'this is an only load', ->
         context '#_shouldUseOnly returns true', ->

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -464,7 +464,8 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
       loader = createLoader()
       opts = _.extend defaultLoadOptions(),
         cache: false
-        feature_name: 'a-feature'
+        headers:
+          'X-Feature-Name': 'a-feature'
       opts.include = fakeNestedInclude
 
       loader.setup(opts)
@@ -488,7 +489,7 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
       expect(calls.count()).toBeGreaterThan(0)
 
       for call in calls.all()
-        expect(call.args[1].feature_name).toBe('a-feature')
+        expect(call.args[1].headers['X-Feature-Name']).toBe('a-feature')
 
     it 'creates a request for each additional include and calls #_onLoadingCompleted when they all are done', ->
       promises = []

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -28,7 +28,7 @@ describe "Sync", ->
         expect(setRequestHeader).not.toHaveBeenCalledWith('X-Feature-Name', undefined)
 
       it 'settable via feature_name', ->
-        jqXhr = collection.fetch(feature_name: 'ima-feature')
+        jqXhr = collection.fetch(headers: featureName: 'ima-feature')
         beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
         beforeSend({ setRequestHeader })
         expect(setRequestHeader).toHaveBeenCalledWith('X-Feature-Name', 'ima-feature')

--- a/spec/sync-spec.coffee
+++ b/spec/sync-spec.coffee
@@ -11,28 +11,6 @@ describe "Sync", ->
   beforeEach ->
     ajaxSpy = spyOn(Backbone.$, 'ajax')
 
-  describe 'custom headers', ->
-    beforeSend = null
-    collection = null
-    setRequestHeader = null
-
-    describe 'X-Feature-Name', ->
-      beforeEach ->
-        collection = new TimeEntries()
-        setRequestHeader = jasmine.createSpy('setRequestHeader')
-
-      it 'is not undefined', ->
-        jqXhr = collection.fetch()
-        beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
-        beforeSend({ setRequestHeader })
-        expect(setRequestHeader).not.toHaveBeenCalledWith('X-Feature-Name', undefined)
-
-      it 'settable via feature_name', ->
-        jqXhr = collection.fetch(headers: featureName: 'ima-feature')
-        beforeSend = ajaxSpy.calls.mostRecent().args[0].beforeSend
-        beforeSend({ setRequestHeader })
-        expect(setRequestHeader).toHaveBeenCalledWith('X-Feature-Name', 'ima-feature')
-
   describe "updating models", ->
     it "should use toServerJSON instead of toJSON", ->
       modelSpy = spyOn(Model.prototype, 'toServerJSON')

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -307,7 +307,6 @@ class AbstractLoader
     options = @loadOptions
     syncOptions =
       data: {}
-      headers: @loadOptions.headers
       parse: true
       error: @_onServerLoadError
       success: @_onServerLoadSuccess

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -278,7 +278,7 @@ class AbstractLoader
     for association in @additionalIncludes
       loadOptions =
         cache: @loadOptions.cache
-        feature_name: @loadOptions.feature_name
+        headers: @loadOptions.headers
         only: association.ids
         params:
           apply_default_filters: false

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -307,6 +307,7 @@ class AbstractLoader
     options = @loadOptions
     syncOptions =
       data: {}
+      headers: options.headers
       parse: true
       error: @_onServerLoadError
       success: @_onServerLoadSuccess

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -307,7 +307,7 @@ class AbstractLoader
     options = @loadOptions
     syncOptions =
       data: {}
-      featureName: @loadOptions.feature_name
+      headers: @loadOptions.headers
       parse: true
       error: @_onServerLoadError
       success: @_onServerLoadSuccess
@@ -319,7 +319,6 @@ class AbstractLoader
     syncOptions.data.optional_fields = @loadOptions.optionalFields.join(',') if @loadOptions.optionalFields?.length
 
     blacklist = [
-      'feature_name'
       'include'
       'limit'
       'offset'

--- a/src/sync.coffee
+++ b/src/sync.coffee
@@ -82,11 +82,6 @@ module.exports = (method, model, options) ->
   if params.type == 'PATCH' && window.ActiveXObject && !(window.external && window.external.msActiveXFilteringEnabled)
     params.xhr = -> new ActiveXObject('Microsoft.XMLHTTP')
 
-  beforeSend = options.beforeSend
-  options.beforeSend = (xhr) ->
-    xhr.setRequestHeader 'X-Feature-Name', options.headers.featureName if options.headers?.featureName
-    beforeSend?.apply this, arguments
-
   # Make the request, allowing the user to override any Ajax options.
   xhr = options.xhr = Backbone.ajax(_.extend(params, options))
   model.trigger 'request', model, xhr, options

--- a/src/sync.coffee
+++ b/src/sync.coffee
@@ -84,7 +84,7 @@ module.exports = (method, model, options) ->
 
   beforeSend = options.beforeSend
   options.beforeSend = (xhr) ->
-    xhr.setRequestHeader 'X-Feature-Name', options.featureName if options.featureName
+    xhr.setRequestHeader 'X-Feature-Name', options.headers.featureName if options.headers?.featureName
     beforeSend?.apply this, arguments
 
   # Make the request, allowing the user to override any Ajax options.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Is the feature a substantial feature request? -->

No.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Follow-up to https://github.com/mavenlink/brainstem-js/pull/126

Looks like `feature_name` can sometimes be an actual filter name. This tries to avoid clobbering filter names by nesting in a namespace.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<!-- Requirement for Mavenlink engineers: Provide links to any related product requirements and builds using this changeset (e.g. brainstem-redux, mavenlink-js, mavenlink/mavenlink. -->
