### PR TITLE
Load associated records in chunks if necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -508,6 +508,27 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
 
       expect(loader._onLoadingCompleted).toHaveBeenCalled()
 
+    describe 'batching', ->
+      beforeEach ->
+        spyOn(loader, '_getIdsForAssociation').and.returnValue [1, 2, 3, 4, 5]
+        spyOn(loader.storageManager, 'loadObject')
+
+      context 'there are less than the associated ID limit', ->
+        beforeEach ->
+          loader.associationIdLimit = 100
+
+        it 'makes a single request for each association', ->
+          loader._loadAdditionalIncludes()
+          expect(loader.storageManager.loadObject.calls.count()).toEqual 2
+
+      context 'there are more than the associated ID limit', ->
+        beforeEach ->
+          loader.associationIdLimit = 2
+
+        it 'makes multiple requests for each association', ->
+          loader._loadAdditionalIncludes()
+          expect(loader.storageManager.loadObject.calls.count()).toEqual 6
+
   describe '#_buildSyncOptions', ->
     syncOptions = opts = null
 

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -83,3 +83,15 @@ describe 'Brainstem Utils', ->
       it 'sets a function on options.error', ->
         expect(options.error).toBeDefined()
         expect(options.error).toEqual(jasmine.any(Function))
+
+  describe '.chunk', ->
+    it 'returns an array of arrays of specified length', ->
+      expect(Utils.chunk([1, 2, 3, 4], 2)).toEqual [[1, 2], [3, 4]]
+
+    context 'when array is not an array', ->
+      it 'returns an empty array', ->
+        expect(Utils.chunk(null, 2)).toEqual []
+
+    context 'when count is null or 0', ->
+      it 'returns empty', ->
+        expect(Utils.chunk([1, 2], null)).toEqual []

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -88,10 +88,17 @@ describe 'Brainstem Utils', ->
     it 'returns an array of arrays of specified length', ->
       expect(Utils.chunk([1, 2, 3, 4], 2)).toEqual [[1, 2], [3, 4]]
 
-    context 'when array is not an array', ->
-      it 'returns an empty array', ->
-        expect(Utils.chunk(null, 2)).toEqual []
+    it 'handles counts that do not divide evenly into the array length', ->
+      expect(Utils.chunk([1, 2, 3, 4, 5], 2)).toEqual [[1, 2], [3, 4], [5]]
 
-    context 'when count is null or 0', ->
-      it 'returns empty', ->
-        expect(Utils.chunk([1, 2], null)).toEqual []
+    it 'handles non-arrays', ->
+      expect(Utils.chunk(null, 2)).toEqual []
+
+    it 'handles non-number counts', ->
+      expect(Utils.chunk([1, 2], null)).toEqual []
+
+    it 'handles a count of zero', ->
+      expect(Utils.chunk([1, 2], 0)).toEqual []
+
+    it 'handles a negative count', ->
+      expect(Utils.chunk([1, 2], -1)).toEqual []

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -279,7 +279,7 @@ class AbstractLoader
     for association in @additionalIncludes
       batches = Utils.chunk(association.ids, @associationIdLimit)
       batchPromises = batches.map(@_loadAdditionalIncludesBatch.bind(this, association))
-      promises = promises.concat(batchPromises)
+      promises.push(batchPromises...)
 
     $.when.apply($, promises)
       .done(@_onLoadingCompleted)

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -80,5 +80,14 @@ class Utils
 
     gpo(obj) == proto
 
+  # Chunk is in underscore 1.9.1, but not 1.8.3, which we're currently on.
+  @chunk: (array, count) ->
+    return [] if !Array.isArray(array) || count == null || count < 1
+    result = []
+    i = 0
+    while i < array.length
+      result.push(array.slice(i, i += count))
+    result
+
 
 module.exports = Utils


### PR DESCRIPTION
Related to https://www.pivotaltracker.com/story/show/158237926, corresponds to https://github.com/mavenlink/mavenlink/pull/13016

Associated records can be loaded via the "only" param in the URL. When there are many associated records, this can go over the URL limit (which is around 2000 characters or so).

We cannot detect what the actual length of our URL will be, because there are filters and custom subdomains involved as well. Instead, we use a heuristic of allowing 150 ids.

We got there by:

(2000 max URL limit - 500 max filters length - 100 max subdomain length) / 11 max id length (including comma) == about 150-ish

All of the "max" values above are assumed to be "reasonable" limits.