### PR TITLE
Fix incorrect regex where the string could just contain a Z and pass

### DIFF
--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -427,8 +427,8 @@ describe 'Model', ->
         expect(storageManager.storage('users').get(6).get('created_at')).toEqual(1359573957000)
 
       it "does not handle ISO 8601 dates with other characters", ->
-        parsed = model.parse({created_at: "blargh 2013-01-25T11:25:57-08:00 churgh"})
-        expect(parsed.created_at).toEqual("blargh 2013-01-25T11:25:57-08:00 churgh")
+        parsed = model.parse({created_at: "blargh 2013-01-25T11:25:57-08:00 churghZ"})
+        expect(parsed.created_at).toEqual("blargh 2013-01-25T11:25:57-08:00 churghZ")
 
       it "parses a UTC date", ->
         parsed = model.parse({created_at: "2019-04-23T18:30:29Z"})

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -56,7 +56,7 @@ class Model extends Backbone.Model
   @parse: (modelObject) ->
     for k,v of modelObject
       # Date.parse will parse ISO 8601 in ECMAScript 5, but we include a shim for now
-      if isDateAttr(k) && /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}[-+]\d{2}:\d{2}|Z$/.test(v)
+      if isDateAttr(k) && /^\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}([-+]\d{2}:\d{2}|Z)$/.test(v)
         modelObject[k] = Date.parse(v)
     return modelObject
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This fixes an issue where the string could just contain a Z and be considered a valid iso8601 timestamp. 

**Test plan**

We added tests that ensured strings with a z would not always be considered valid, they must have the rest of the regex matching. 
