### PR TITLE
Propagate response as part of the sync event for a collection

### DIFF
--- a/spec/collection-spec.coffee
+++ b/spec/collection-spec.coffee
@@ -231,7 +231,7 @@ describe 'Collection', ->
 
         collection.fetch(options)
         expectation.respond()
-        expect(collection.trigger).toHaveBeenCalledWith('sync', collection, jasmine.any(Array), jasmine.any(Object), jasmine.any(Object))
+        expect(collection.trigger).toHaveBeenCalledWith('sync', collection, jasmine.any(Array), jasmine.any(Object), jasmine.any(String))
 
       context 'reset option is set to false', ->
         beforeEach ->

--- a/spec/helpers/spec-helper.coffee
+++ b/spec/helpers/spec-helper.coffee
@@ -29,13 +29,17 @@ window.convertTopLevelKeysToObjects = (data) ->
     continue if key in ["count", "results"]
     if data[key] instanceof Array
       data[key] = _(data[key]).reduce(((memo, item) -> memo[item.id] = item; memo ), {})
+  data
 
-window.respondWith = (server, url, options) ->
+window.formatResponseData = (options) ->
   if options.resultsFrom?
     data = $.extend {}, options.data, results: resultsArray(options.resultsFrom, options.data[options.resultsFrom])
   else
     data = options.data
   convertTopLevelKeysToObjects data
+
+window.respondWith = (server, url, options) ->
+  data = formatResponseData(options)
   server.respondWith options.method || "GET",
                      url, [ options.status || 200,
                            {"Content-Type": options.content_type || "application/json"},
@@ -93,6 +97,7 @@ window.clearLiveEventBindings = ->
 
 window.context = describe
 window.xcontext = xdescribe
+window.fcontext = fdescribe
 
 # Shared Behaviors
 window.SharedBehaviors ?= {};

--- a/spec/helpers/spec-helper.coffee
+++ b/spec/helpers/spec-helper.coffee
@@ -24,22 +24,24 @@ window.resultsObject = (models) ->
     results[model.id] = model
   results
 
+window.formatJSONResponse = (collectionName, models) ->
+  responseData = {}
+  responseData[collectionName] = resultsObject(models)
+  responseData.results = resultsArray(collectionName, models)
+  JSON.stringify(responseData)
+
 window.convertTopLevelKeysToObjects = (data) ->
   for key in _(data).keys()
     continue if key in ["count", "results"]
     if data[key] instanceof Array
       data[key] = _(data[key]).reduce(((memo, item) -> memo[item.id] = item; memo ), {})
-  data
 
-window.formatResponseData = (options) ->
+window.respondWith = (server, url, options) ->
   if options.resultsFrom?
     data = $.extend {}, options.data, results: resultsArray(options.resultsFrom, options.data[options.resultsFrom])
   else
     data = options.data
   convertTopLevelKeysToObjects data
-
-window.respondWith = (server, url, options) ->
-  data = formatResponseData(options)
   server.respondWith options.method || "GET",
                      url, [ options.status || 200,
                            {"Content-Type": options.content_type || "application/json"},

--- a/spec/loaders/abstract-loader-shared-behavior.coffee
+++ b/spec/loaders/abstract-loader-shared-behavior.coffee
@@ -741,8 +741,8 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
     it 'calls #_onServerLoadSuccess with the result from #_updateStorageManagerFromResponse', ->
       loader._updateStorageManagerFromResponse.and.returnValue 'data'
 
-      loader._onServerLoadSuccess()
-      expect(loader._onLoadSuccess).toHaveBeenCalledWith 'data'
+      loader._onServerLoadSuccess('response')
+      expect(loader._onLoadSuccess).toHaveBeenCalledWith 'data', 'response'
 
   describe '#_onLoadSuccess', ->
     beforeEach ->
@@ -753,25 +753,25 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
       spyOn(loader, '_calculateAdditionalIncludes')
 
     it 'calls #_updateObjects with the internalObject, the data, and silent set to true', ->
-      loader._onLoadSuccess('test data')
+      loader._onLoadSuccess('test data', 'response')
       expect(loader._updateObjects).toHaveBeenCalledWith(loader.internalObject, 'test data', true)
 
     it 'calls #_calculateAdditionalIncludes', ->
-      loader._onLoadSuccess()
+      loader._onLoadSuccess('test data', 'response')
       expect(loader._calculateAdditionalIncludes).toHaveBeenCalled()
 
     context 'additional includes are needed', ->
       it 'calls #_loadAdditionalIncludes', ->
         loader._calculateAdditionalIncludes.and.callFake -> @additionalIncludes = ['foo']
 
-        loader._onLoadSuccess()
+        loader._onLoadSuccess('test data', 'response')
         expect(loader._loadAdditionalIncludes).toHaveBeenCalled()
         expect(loader._onLoadingCompleted).not.toHaveBeenCalled()
 
     context 'additional includes are not needed', ->
       it 'calls #_onLoadingCompleted', ->
-        loader._onLoadSuccess()
-        expect(loader._onLoadingCompleted).toHaveBeenCalled()
+        loader._onLoadSuccess('test data', 'response')
+        expect(loader._onLoadingCompleted).toHaveBeenCalledWith('response')
         expect(loader._loadAdditionalIncludes).not.toHaveBeenCalled()
 
   describe '#_onLoadingCompleted', ->
@@ -779,12 +779,12 @@ registerSharedBehavior "AbstractLoaderSharedBehavior", (sharedContext) ->
       loader = createLoader()
 
     it 'calls #_updateObjects with the externalObject and internalObject', ->
-      loader._onLoadingCompleted()
+      loader._onLoadingCompleted('response')
       expect(loader._updateObjects).toHaveBeenCalledWith(loader.externalObject, loader.internalObject)
 
     it 'resolves the deferred object with the externalObject', ->
       spy = jasmine.createSpy()
       loader.then(spy)
 
-      loader._onLoadingCompleted()
-      expect(spy).toHaveBeenCalledWith(loader.externalObject)
+      loader._onLoadingCompleted('response')
+      expect(spy).toHaveBeenCalledWith(loader.externalObject, 'response')

--- a/spec/storage-manager-spec.coffee
+++ b/spec/storage-manager-spec.coffee
@@ -350,12 +350,14 @@ describe 'Brainstem Storage Manager', ->
 
     it "accepts a success function", ->
       timeEntries = [buildTimeEntry(), buildTimeEntry()]
-      respondWith server, "/api/time_entries?per_page=20&page=1", resultsFrom: "time_entries", data: { time_entries: timeEntries }
+      responseData = { time_entries: resultsObject(timeEntries), results: resultsArray("time_entries", timeEntries) }
+      respondWith server, "/api/time_entries?per_page=20&page=1", data: responseData
       spy = jasmine.createSpy().and.callFake (collection) ->
         expect(collection.loaded).toBe true
       collection = manager.loadCollection "time_entries", success: spy
       server.respond()
-      expect(spy).toHaveBeenCalledWith(collection)
+      expectedResponse = JSON.parse(JSON.stringify(responseData))
+      expect(spy).toHaveBeenCalledWith(collection, expectedResponse)
 
     it "saves it's options onto the returned collection", ->
       collection = manager.loadCollection "time_entries", order: "baz:desc", filters: { bar: 2 }
@@ -510,7 +512,7 @@ describe 'Brainstem Storage Manager', ->
 
               server.respond() until server.queue.length == 0
 
-              expect(success).toHaveBeenCalledWith(collection)
+              expect(success).toHaveBeenCalledWith(collection, jasmine.any(Object))
               expect(callCount).toEqual 3
 
           context 'using a backbone collection', ->

--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -99,8 +99,9 @@ module.exports = class Collection extends Backbone.Collection
 
     @trigger('request', this, xhr, options)
 
-    loader.then(-> loader.internalObject.models)
-      .done((response) =>
+    loader.then((_, response) -> [loader.internalObject.models, response])
+      .done((modelsAndResponse) =>
+        [models, response] = modelsAndResponse
         @lastFetchOptions = loader.externalObject.lastFetchOptions
 
         if options.add
@@ -110,9 +111,9 @@ module.exports = class Collection extends Backbone.Collection
         else
           method = 'set'
 
-        @[method](response, options)
+        @[method](models, options)
 
-        @trigger('sync', this, response, options)
+        @trigger('sync', this, models, options, response)
       )
       .then(-> loader.externalObject)
       .promise(xhr)

--- a/src/expectation.coffee
+++ b/src/expectation.coffee
@@ -49,7 +49,7 @@ module.exports = class Expectation
     else
       returnedData = @_handleModelResults(loader)
 
-    loader._onLoadSuccess(returnedData)
+    loader._onLoadSuccess(returnedData, this)
 
   recordRequest: (loader) ->
     if @immediate

--- a/src/expectation.coffee
+++ b/src/expectation.coffee
@@ -49,7 +49,7 @@ module.exports = class Expectation
     else
       returnedData = @_handleModelResults(loader)
 
-    loader._onLoadSuccess(returnedData, this)
+    loader._onLoadSuccess(returnedData, @_formatResponse(loader))
 
   recordRequest: (loader) ->
     if @immediate
@@ -151,3 +151,11 @@ module.exports = class Expectation
 
     existingModel.set(attributes)
     existingModel
+
+  _formatResponse: (loader) ->
+    if loader?.loadOptions?.response
+      collectionName = loader.loadOptions.name
+      models = loader.loadOptions.response(this)
+      formatJSONResponse(collectionName, models)
+    else
+      '{}'

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -378,14 +378,14 @@ class AbstractLoader
 
   ###*
    * Called when the Backbone.sync successfully responds from the server.
-   * @param  {object} resp    JSON response from the server.
+   * @param  {object} response JSON response from the server.
    * @param  {string} _status
    * @param  {object} _xhr    jQuery XHR object
    * @return {undefined}
   ###
-  _onServerLoadSuccess: (resp, _status, _xhr) =>
-    data = @_updateStorageManagerFromResponse(resp)
-    @_onLoadSuccess(data)
+  _onServerLoadSuccess: (response, _status, _xhr) =>
+    data = @_updateStorageManagerFromResponse(response)
+    @_onLoadSuccess(data, response)
 
   ###*
    * Called when the Backbone.sync has errored.
@@ -400,25 +400,27 @@ class AbstractLoader
    * Updates the internalObject with the data in the storageManager and either loads more data or resolves this load.
    * Called after sync + storage manager updating.
    * @param  {array|object} data array of models or model from _updateStorageManagerFromResponse
+   * @param  {object} response JSON response from the server.
    * @return {undefined}
   ###
-  _onLoadSuccess: (data) ->
+  _onLoadSuccess: (data, response) ->
     @_updateObjects(@internalObject, data, true)
     @_calculateAdditionalIncludes()
 
     if @additionalIncludes.length
       @_loadAdditionalIncludes()
     else
-      @_onLoadingCompleted()
+      @_onLoadingCompleted(response)
 
   ###*
    * Called when all loading (including nested loads) are complete.
    * Updates the `externalObject` with the data that was gathered and resolves the promise.
+   * @param  {object} response JSON response from the server.
    * @return {undefined}
   ###
-  _onLoadingCompleted: =>
+  _onLoadingCompleted: (response) =>
     @_updateObjects(@externalObject, @internalObject)
-    @_deferred.resolve(@externalObject)
+    @_deferred.resolve(@externalObject, response)
 
 
 module.exports = AbstractLoader


### PR DESCRIPTION
**Summary**

<!-- Is the feature a substantial feature request? -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The motivation was to allow for more flexibility in terms of accessing data in the response that does not belong as part of the collection of models. We are introducing the capability to specify a `update_allowlist` for each collection as part of the `meta` attribute in the response.

Here's an example of the response:
```
{
  results: [ { key: 'posts', id: '123' }],
  posts: { '123': {...} }
  replies: { '456': {...} }
  meta: {
    'count': 1,
    'page': 1,
    'update_allowlist': {
      'posts': ['message', 'user_id'...],
      'replies': ['reply_message', 'replier_id'...],
    }
  }
}
```

Without passing the response as part of the sync, we are unable to tap into this metadata

**Test plan**

We have updated the specs to include response as part of the parameter list. We will also link the `mavenlink-js` & `bigmaven` PRs in here

**Mavenlink-JS PR**: https://github.com/mavenlink/mavenlink-js/pull/602

TODO:
- [ ] package.json has updated version with NPM