### PR TITLE
Add the capability to tap into the raw response if needed

### DIFF
--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -955,6 +955,22 @@ describe 'Model', ->
           for key in allowlist
             expect(json[key]).toBeTruthy()
 
+        context 'when createJSONAllowlist returns an empty value', ->
+          beforeEach ->
+            expectedBlocklist = ['possums', 'racoons', 'potatoes']
+
+            model.createJSONBlocklist = ->
+              expectedBlocklist
+
+            model.createJSONAllowlist = ->
+              undefined
+
+          it 'defaults back to the blocklist', ->
+            json = model.toServerJSON("create")
+
+            for key in expectedBlocklist
+              expect(json[key]).toBeUndefined()
+
       context 'update', ->
         it "sets the blocklist to the model's attributes except for those in the allowlist", ->
           json = model.toServerJSON("update")
@@ -964,6 +980,22 @@ describe 'Model', ->
 
           for key in allowlist
             expect(json[key]).toBeTruthy()
+
+        context 'when updateJSONAllowlist returns an empty value', ->
+          beforeEach ->
+            expectedBlocklist = ['possums', 'racoons', 'potatoes']
+
+            model.updateJSONBlocklist = ->
+              expectedBlocklist
+
+            model.updateJSONAllowlist = ->
+              undefined
+
+          it 'defaults back to the blocklist', ->
+            json = model.toServerJSON("update")
+
+            for key in expectedBlocklist
+              expect(json[key]).toBeUndefined()
 
   describe '#_linkCollection', ->
     story = null

--- a/src/loaders/abstract-loader.coffee
+++ b/src/loaders/abstract-loader.coffee
@@ -378,14 +378,14 @@ class AbstractLoader
 
   ###*
    * Called when the Backbone.sync successfully responds from the server.
-   * @param  {object} resp    JSON response from the server.
+   * @param  {object} response JSON response from the server.
    * @param  {string} _status
    * @param  {object} _xhr    jQuery XHR object
    * @return {undefined}
   ###
-  _onServerLoadSuccess: (resp, _status, _xhr) =>
-    data = @_updateStorageManagerFromResponse(resp)
-    @_onLoadSuccess(data)
+  _onServerLoadSuccess: (response, _status, _xhr) =>
+    data = @_updateStorageManagerFromResponse(response)
+    @_onLoadSuccess(data, response)
 
   ###*
    * Called when the Backbone.sync has errored.
@@ -400,10 +400,12 @@ class AbstractLoader
    * Updates the internalObject with the data in the storageManager and either loads more data or resolves this load.
    * Called after sync + storage manager updating.
    * @param  {array|object} data array of models or model from _updateStorageManagerFromResponse
+   * @param  {object} response JSON response from the server.
    * @return {undefined}
   ###
-  _onLoadSuccess: (data) ->
+  _onLoadSuccess: (data, response) ->
     @_updateObjects(@internalObject, data, true)
+    @externalObject.trigger('response', this, response)
     @_calculateAdditionalIncludes()
 
     if @additionalIncludes.length

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -269,12 +269,12 @@ class Model extends Backbone.Model
 
     switch method
       when 'create'
-        if @createJSONAllowlist
+        if @createJSONAllowlist && !_.isEmpty(@createJSONAllowlist())
           blocklist = _.difference(Object.keys(@attributes), @createJSONAllowlist())
         else
           blocklist = blocklist.concat @createJSONBlocklist()
       when 'update'
-        if @updateJSONAllowlist
+        if @updateJSONAllowlist && !_.isEmpty(@updateJSONAllowlist())
           blocklist = _.difference(Object.keys(@attributes), @updateJSONAllowlist())
         else
           blocklist = blocklist.concat @updateJSONBlocklist()


### PR DESCRIPTION
**Summary**

<!-- Is the feature a substantial feature request? -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The motivation was to allow for more flexibility in terms of accessing data in the response that does not belong as part of the collection of models. We are introducing the capability to specify a `update_allowlist` for each collection as part of the `meta` attribute in the response.

Here's an example of the response:
```
{
  results: [ { key: 'posts', id: '123' }],
  posts: { '123': {...} }
  replies: { '456': {...} }
  meta: {
    'count': 1,
    'page': 1,
    'update_allowlist': {
      'posts': ['message', 'user_id'...],
      'replies': ['reply_message', 'replier_id'...],
    }
  }
}
```

Without passing the response as part of the sync, we are unable to tap into this metadata

**Test plan**

We have updated the specs to include response as part of the parameter list. We will also link the `mavenlink-js` & `bigmaven` PRs in here

**Mavenlink-JS PR**: https://github.com/mavenlink/mavenlink-js/pull/602

TODO:
- [ ] package.json has updated version with NPM