### PR TITLE
Allow passing silent option to backbone Collection#add

### DIFF
--- a/spec/collection-spec.coffee
+++ b/spec/collection-spec.coffee
@@ -234,6 +234,20 @@ describe 'Collection', ->
 
         expect(collection.trigger).toHaveBeenCalledWith('sync', collection, jasmine.any(Array), jasmine.any(Object))
 
+      describe 'Collection#update silent option', ->
+        beforeEach ->
+          spyOn(Collection.prototype, 'update')
+
+        it 'is true when silent is true', ->
+          collection.fetch(_.extend(options, silent: true))
+          expectation.respond()
+          expect(Collection.prototype.update).toHaveBeenCalledWith(jasmine.any(Array), true)
+
+        it 'is false when silent is false', ->
+          collection.fetch(_.extend(options, silent: false))
+          expectation.respond()
+          expect(Collection.prototype.update).toHaveBeenCalledWith(jasmine.any(Array), false)
+
       context 'reset option is set to false', ->
         beforeEach ->
           options.reset = false
@@ -416,6 +430,25 @@ describe 'Collection', ->
       collection.update updateArray
       expect(model.get('title')).toEqual '1 new'
       expect(spy).toHaveBeenCalled()
+
+    context 'when the silent option is true', ->
+      it 'should call Backbone.Collection#add with { silent: true }', ->
+        spyOn(collection, 'add')
+        collection.update updateArray, true
+        expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), { silent: true })
+
+    context 'when the silent option is false', ->
+      it 'should call Backbone.Collection#add with no options', ->
+        spyOn(collection, 'add')
+        collection.update updateArray, false
+        expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), {})
+
+    context 'when the silent option is undefined', ->
+      it 'should call Backbone.Collection#add with no options', ->
+        spyOn(collection, 'add')
+        collection.update updateArray
+        expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), {})
+
 
   describe '#reload', ->
     it 'reloads the collection with the original params', ->

--- a/spec/collection-spec.coffee
+++ b/spec/collection-spec.coffee
@@ -241,12 +241,12 @@ describe 'Collection', ->
         it 'is true when silent is true', ->
           collection.fetch(_.extend(options, silent: true))
           expectation.respond()
-          expect(Collection.prototype.update).toHaveBeenCalledWith(jasmine.any(Array), true)
+          expect(Collection.prototype.update).toHaveBeenCalledWith(jasmine.any(Array), silent: true)
 
         it 'is false when silent is false', ->
           collection.fetch(_.extend(options, silent: false))
           expectation.respond()
-          expect(Collection.prototype.update).toHaveBeenCalledWith(jasmine.any(Array), false)
+          expect(Collection.prototype.update).toHaveBeenCalledWith(jasmine.any(Array), silent: false)
 
       context 'reset option is set to false', ->
         beforeEach ->
@@ -434,14 +434,14 @@ describe 'Collection', ->
     context 'when the silent option is true', ->
       it 'should call Backbone.Collection#add with { silent: true }', ->
         spyOn(collection, 'add')
-        collection.update updateArray, true
+        collection.update updateArray, silent: true
         expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), { silent: true })
 
     context 'when the silent option is false', ->
       it 'should call Backbone.Collection#add with no options', ->
         spyOn(collection, 'add')
-        collection.update updateArray, false
-        expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), {})
+        collection.update updateArray, silent: false
+        expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), { silent: false })
 
     context 'when the silent option is undefined', ->
       it 'should call Backbone.Collection#add with no options', ->

--- a/spec/collection-spec.coffee
+++ b/spec/collection-spec.coffee
@@ -438,7 +438,7 @@ describe 'Collection', ->
         expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), { silent: true })
 
     context 'when the silent option is false', ->
-      it 'should call Backbone.Collection#add with no options', ->
+      it 'should call Backbone.Collection#add with { silent: false }', ->
         spyOn(collection, 'add')
         collection.update updateArray, silent: false
         expect(collection.add).toHaveBeenCalledWith(jasmine.anything(), { silent: false })

--- a/spec/loaders/collection-loader-spec.coffee
+++ b/spec/loaders/collection-loader-spec.coffee
@@ -176,8 +176,8 @@ describe 'Loaders CollectionLoader', ->
           spyOn(Collection.prototype, 'update')
           fakeResponse =
             count: 1,
-            results: [{ key: "tasks", id: 1 }]
-            tasks: [{ id: 1, title: "title" }]
+            results: [{ key: 'tasks', id: 1 }]
+            tasks: [{ id: 1, title: 'title' }]
 
         context 'when the silent argument is true', ->
           beforeEach ->
@@ -185,16 +185,15 @@ describe 'Loaders CollectionLoader', ->
             loader._updateStorageManagerFromResponse(fakeResponse)
 
           it 'calls Collection#update with silent=true', ->
-            expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, true)
+            expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, silent: true)
 
         context 'when the silent argument is false', ->
           beforeEach ->
             loader.setup(_.extend(opts, silent: false))
             loader._updateStorageManagerFromResponse(fakeResponse)
 
-          it 'calls Collection#update with silent=true', ->
-            expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, false)
-
+          it 'calls Collection#update with silent: false', ->
+            expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, silent: false)
 
       describe 'updating the cache', ->
         it 'caches the count from the response in the cacheObject', ->

--- a/spec/loaders/collection-loader-spec.coffee
+++ b/spec/loaders/collection-loader-spec.coffee
@@ -184,7 +184,7 @@ describe 'Loaders CollectionLoader', ->
             loader.setup(_.extend(opts, silent: true))
             loader._updateStorageManagerFromResponse(fakeResponse)
 
-          it 'calls Collection#update with silent=true', ->
+          it 'calls Collection#update with { silent: true }', ->
             expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, silent: true)
 
         context 'when the silent argument is false', ->
@@ -192,7 +192,7 @@ describe 'Loaders CollectionLoader', ->
             loader.setup(_.extend(opts, silent: false))
             loader._updateStorageManagerFromResponse(fakeResponse)
 
-          it 'calls Collection#update with silent: false', ->
+          it 'calls Collection#update with { silent: false }', ->
             expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, silent: false)
 
       describe 'updating the cache', ->

--- a/spec/loaders/collection-loader-spec.coffee
+++ b/spec/loaders/collection-loader-spec.coffee
@@ -4,6 +4,7 @@ Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
 StorageManager = require '../../src/storage-manager'
 CollectionLoader = require '../../src/loaders/collection-loader'
+Collection = require '../../src/collection'
 
 Task = require '../helpers/models/task'
 Tasks = require '../helpers/models/tasks'
@@ -169,6 +170,31 @@ describe 'Loaders CollectionLoader', ->
             { key: "tasks", id: 4 }
             { key: "tasks", id: 5 }
           ]
+
+      describe 'forwarding the silent argument to Collection#update', ->
+        beforeEach ->
+          spyOn(Collection.prototype, 'update')
+          fakeResponse =
+            count: 1,
+            results: [{ key: "tasks", id: 1 }]
+            tasks: [{ id: 1, title: "title" }]
+
+        context 'when the silent argument is true', ->
+          beforeEach ->
+            loader.setup(_.extend(opts, silent: true))
+            loader._updateStorageManagerFromResponse(fakeResponse)
+
+          it 'calls Collection#update with silent=true', ->
+            expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, true)
+
+        context 'when the silent argument is false', ->
+          beforeEach ->
+            loader.setup(_.extend(opts, silent: false))
+            loader._updateStorageManagerFromResponse(fakeResponse)
+
+          it 'calls Collection#update with silent=true', ->
+            expect(Collection.prototype.update).toHaveBeenCalledWith(fakeResponse.tasks, false)
+
 
       describe 'updating the cache', ->
         it 'caches the count from the response in the cacheObject', ->

--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -126,7 +126,7 @@ module.exports = class Collection extends Backbone.Collection
     @loaded = state
     @trigger 'loaded', this if state && options.trigger
 
-  update: (models, silent=false) ->
+  update: (models, silent = false) ->
     models = models.models if models.models?
     for model in models
       model = this.model.parse(model) if this.model.parse?

--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -126,7 +126,8 @@ module.exports = class Collection extends Backbone.Collection
     @loaded = state
     @trigger 'loaded', this if state && options.trigger
 
-  update: (models, silent = false) ->
+  update: (models, options = {}) ->
+    addOpts = _.pick(options, 'silent')
     models = models.models if models.models?
     for model in models
       model = this.model.parse(model) if this.model.parse?
@@ -135,9 +136,7 @@ module.exports = class Collection extends Backbone.Collection
         if modelInCollection = @get(backboneModel.id)
           modelInCollection.set backboneModel.attributes
         else
-          opts = {}
-          opts.silent = true if silent
-          @add(backboneModel, opts)
+          @add(backboneModel, addOpts)
       else
         Utils.warn 'Unable to update collection with invalid model', model
 

--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -21,6 +21,7 @@ module.exports = class Collection extends Backbone.Collection
     'cache'
     'cacheKey'
     'optionalFields'
+    'silent'
   ]
 
   @getComparatorWithIdFailover: (order) ->
@@ -125,7 +126,7 @@ module.exports = class Collection extends Backbone.Collection
     @loaded = state
     @trigger 'loaded', this if state && options.trigger
 
-  update: (models) ->
+  update: (models, silent=false) ->
     models = models.models if models.models?
     for model in models
       model = this.model.parse(model) if this.model.parse?
@@ -134,7 +135,9 @@ module.exports = class Collection extends Backbone.Collection
         if modelInCollection = @get(backboneModel.id)
           modelInCollection.set backboneModel.attributes
         else
-          @add backboneModel
+          opts = {}
+          opts.silent = true if silent
+          @add(backboneModel, opts)
       else
         Utils.warn 'Unable to update collection with invalid model', model
 

--- a/src/expectation.coffee
+++ b/src/expectation.coffee
@@ -119,7 +119,7 @@ module.exports = class Expectation
 
     for result in @results
       if result instanceof @Model
-        @manager.storage(result.brainstemKey).update [result]
+        @manager.storage(result.brainstemKey).update [result], loader.loadOptions.silent
 
     returnedModels = _.map @results, (result) =>
       if result instanceof @Model

--- a/src/expectation.coffee
+++ b/src/expectation.coffee
@@ -119,7 +119,7 @@ module.exports = class Expectation
 
     for result in @results
       if result instanceof @Model
-        @manager.storage(result.brainstemKey).update [result], loader.loadOptions.silent
+        @manager.storage(result.brainstemKey).update [result], silent: loader.loadOptions.silent
 
     returnedModels = _.map @results, (result) =>
       if result instanceof @Model

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -79,7 +79,7 @@ class CollectionLoader extends AbstractLoader
       keys.push(@loadOptions.name)
 
     for underscoredModelName in keys
-      @storageManager.storage(underscoredModelName).update _(resp[underscoredModelName]).values()
+      @storageManager.storage(underscoredModelName).update(_(resp[underscoredModelName]).values(), @loadOptions.silent)
 
     cachedData =
       count: resp.count

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -79,7 +79,10 @@ class CollectionLoader extends AbstractLoader
       keys.push(@loadOptions.name)
 
     for underscoredModelName in keys
-      @storageManager.storage(underscoredModelName).update(_(resp[underscoredModelName]).values(), silent: @loadOptions.silent)
+      @storageManager.storage(underscoredModelName).update(
+        _(resp[underscoredModelName]).values(),
+        silent: @loadOptions.silent
+      )
 
     cachedData =
       count: resp.count

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -79,7 +79,7 @@ class CollectionLoader extends AbstractLoader
       keys.push(@loadOptions.name)
 
     for underscoredModelName in keys
-      @storageManager.storage(underscoredModelName).update(_(resp[underscoredModelName]).values(), @loadOptions.silent)
+      @storageManager.storage(underscoredModelName).update(_(resp[underscoredModelName]).values(), silent: @loadOptions.silent)
 
     cachedData =
       count: resp.count


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Sometimes we have large collections that we don't to `trigger('add' ....)` on each one for performance reasons

**Test plan**

Everything should be well encapsulated by the specs, and all the changes are opt in so it should not cause any breaking changes.