### PR TITLE
feat: Get operation ignores null or undefined as attribute ids

### DIFF
--- a/spec/model-spec.coffee
+++ b/spec/model-spec.coffee
@@ -806,6 +806,11 @@ describe 'Model', ->
           storageManager.storage("tasks").add { id: 11, title: "Second Task" }
           project = new Project(id: 25, task_ids: [10, 11])
 
+        context "when there are null values in id list" , ->
+          it "ignores the null values", ->
+            project = new Project(id: 25, task_ids: [10, 11, null, undefined])
+            expect(-> project.get('tasks')).not.toThrowError()
+
         context "when association ids is not present", ->
           it "returns an empty collection", ->
             expect(project.get("time_entries").models).toEqual []

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -118,6 +118,8 @@ class Model extends Backbone.Model
         notFoundIds = []
         if ids
           for id in ids
+            if id == null or id == undefined
+              continue
             model = @storageManager.storage(details.collectionName).get(id)
             models.push(model)
             notFoundIds.push(id) unless model


### PR DESCRIPTION
**Summary**

There are some instances where bad data as is loaded into the collection of ids. If those instances of null or undefined they should noop.

**Test plan**

This is tested in the specs