### PR TITLE
Bump underscore from 1.12.1 to 1.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "minimist": "^1.2.0",
     "path": "^0.12.7",
     "sinon": "1.17.3",
-    "underscore": ">= 1.12.1",
+    "underscore": "^1.13.6",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0",
     "yarn-deduplicate": "^6.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4661,10 +4661,10 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-"underscore@>= 1.12.1", underscore@>=1.5.0:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+underscore@>=1.5.0, underscore@^1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 undertaker-registry@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- Bump `underscore` from 1.12.1 to 1.13.6. The [changelog](https://underscorejs.org/#changelog) lists no breaking changes.