### PR TITLE
Use checkout v3 instead of v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: 'latest'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Use checkout v3 instead of v2. We cannot upgrade to v4 because we are not on node 20.