### PR TITLE
Resolve find-parent-dir to v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "yarn-deduplicate": "^6.0.2"
   },
   "resolutions": {
+    "find-parent-dir": "^0.3.1",
     "lodash.template": "^4.5.0"
   },
   "browserify-shim": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,9 +1533,10 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-parent-dir@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+find-parent-dir@^0.3.1, find-parent-dir@~0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.1.tgz#c5c385b96858c3351f95d446cab866cbf9f11125"
+  integrity sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==
 
 find-up@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
Fix deprecation warning:
```
$ gulp build-module
(node:83458) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/georgewang/workspace/brainstem-js/node_modules/find-parent-dir/package.json' of 'find-parent-dir.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```