### PR TITLE
Fix karma server deprecation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,18 +32,19 @@ gulp.task('clean-module', () => {
 });
 
 let configFilePath = path.join(__dirname, 'karma.conf.js');
-let karmaConfig = {
-  configFile: configFilePath,
+let karmaConfigOptions = {
   singleRun: true,
   sourceMaps: true
 };
 
+let parsedKarmaConfig = karma.config.parseConfig(configFilePath, karmaConfigOptions, { throwErrors: true })
+
 if (typeof options.browsers === 'string') {
-  karmaConfig.browsers = options.browsers.split();
+  parsedKarmaConfig.browsers = options.browsers.split();
 }
 
 if (typeof options.grep === 'string') {
-  karmaConfig.client = { args: ['--grep', options.grep] };
+  parsedKarmaConfig.client = { args: ['--grep', options.grep] };
 }
 
 const karmaErrorHandler = function(code) {
@@ -56,17 +57,17 @@ const karmaErrorHandler = function(code) {
 };
 
 gulp.task('test', (done) => {
-  new karmaServer(karmaConfig, karmaErrorHandler.bind(done)).start();
+  new karmaServer(parsedKarmaConfig, karmaErrorHandler.bind(done)).start();
 });
 
 gulp.task('test-ci', (done) => {
-  new karmaServer(Object.assign({}, karmaConfig, {
+  new karmaServer(Object.assign({}, parsedKarmaConfig, {
     browsers: ['Firefox']
   }), karmaErrorHandler.bind(done)).start();
 });
 
 gulp.task('test-watch', (done) => {
-  var config = Object.assign({}, karmaConfig, {
+  var config = Object.assign({}, parsedKarmaConfig, {
     singleRun: false,
     autoWatch: true
   });
@@ -75,7 +76,7 @@ gulp.task('test-watch', (done) => {
 });
 
 gulp.task('test-debug', (done) => {
-  var config = Object.assign({}, karmaConfig, {
+  var config = Object.assign({}, parsedKarmaConfig, {
     browsers: ['Chrome'],
     singleRun: false,
     autoWatch: true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,13 +4,7 @@ const minimist = require('minimist');
 const path = require('path');
 const del = require('del');
 const coffee = require('gulp-coffee');
-const browserify = require('browserify');
-const coffeeify = require('coffeeify');
-const shim = require('browserify-shim');
 const karma = require('karma');
-
-const { version, standalone, filename } = require('./package');
-
 
 const source = './src/**/*.coffee';
 const options = minimist(process.argv.slice(2));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,8 +31,9 @@ gulp.task('clean-module', () => {
   return del(`${moduleOutput}/**/*.js`);
 });
 
+let configFilePath = path.join(__dirname, 'karma.conf.js');
 let karmaConfig = {
-  configFile: path.join(__dirname, 'karma.conf.js'),
+  configFile: configFilePath,
   singleRun: true,
   sourceMaps: true
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ const coffee = require('gulp-coffee');
 const browserify = require('browserify');
 const coffeeify = require('coffeeify');
 const shim = require('browserify-shim');
-const { Server: Karma } = require('karma');
+const karma = require('karma');
 
 const { version, standalone, filename } = require('./package');
 
@@ -16,7 +16,7 @@ const source = './src/**/*.coffee';
 const options = minimist(process.argv.slice(2));
 
 const moduleOutput = './lib';
-
+const karmaServer = karma.Server;
 
 // Tasks
 
@@ -55,11 +55,11 @@ const karmaErrorHandler = function(code) {
 };
 
 gulp.task('test', (done) => {
-  new Karma(karmaConfig, karmaErrorHandler.bind(done)).start();
+  new karmaServer(karmaConfig, karmaErrorHandler.bind(done)).start();
 });
 
 gulp.task('test-ci', (done) => {
-  new Karma(Object.assign({}, karmaConfig, {
+  new karmaServer(Object.assign({}, karmaConfig, {
     browsers: ['Firefox']
   }), karmaErrorHandler.bind(done)).start();
 });
@@ -70,7 +70,7 @@ gulp.task('test-watch', (done) => {
     autoWatch: true
   });
 
-  new Karma(config, karmaErrorHandler.bind(done)).start();
+  new karmaServer(config, karmaErrorHandler.bind(done)).start();
 });
 
 gulp.task('test-debug', (done) => {
@@ -80,7 +80,7 @@ gulp.task('test-debug', (done) => {
     autoWatch: true
   });
 
-  new Karma(config, karmaErrorHandler.bind(done)).start();
+  new karmaServer(config, karmaErrorHandler.bind(done)).start();
 });
 
 gulp.task('ci', gulp.series(gulp.parallel(['test-ci'])));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,19 +61,28 @@ gulp.task('test-ci', (done) => {
 });
 
 gulp.task('test-watch', (done) => {
-  var config = Object.assign({}, parsedKarmaConfig, {
+  let karmaConfigOptions = {
     singleRun: false,
+    sourceMaps: true,
     autoWatch: true
-  });
+  };
 
-  new karmaServer(config, karmaErrorHandler.bind(done)).start();
+  let parsedKarmaConfig = karma.config.parseConfig(configFilePath, karmaConfigOptions, { throwErrors: true })
+
+  new karmaServer(parsedKarmaConfig, karmaErrorHandler.bind(done)).start();
 });
 
 gulp.task('test-debug', (done) => {
+  let karmaConfigOptions = {
+    singleRun: false,
+    sourceMaps: true,
+
+  };
+
+  let parsedKarmaConfig = karma.config.parseConfig(configFilePath, karmaConfigOptions, { throwErrors: true })
+
   var config = Object.assign({}, parsedKarmaConfig, {
     browsers: ['Chrome'],
-    singleRun: false,
-    autoWatch: true
   });
 
   new karmaServer(config, karmaErrorHandler.bind(done)).start();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,16 +76,12 @@ gulp.task('test-debug', (done) => {
   let karmaConfigOptions = {
     singleRun: false,
     sourceMaps: true,
-
+    browsers: ['Chrome'],
   };
 
   let parsedKarmaConfig = karma.config.parseConfig(configFilePath, karmaConfigOptions, { throwErrors: true })
 
-  var config = Object.assign({}, parsedKarmaConfig, {
-    browsers: ['Chrome'],
-  });
-
-  new karmaServer(config, karmaErrorHandler.bind(done)).start();
+  new karmaServer(parsedKarmaConfig, karmaErrorHandler.bind(done)).start();
 });
 
 gulp.task('ci', gulp.series(gulp.parallel(['test-ci'])));


### PR DESCRIPTION
Fix Karma deprecation warning:
```
06 03 2024 09:04:09.491:WARN [karma-server]: Passing raw CLI options to `new Server(config, done)` is deprecated. Use `parseConfig(configFilePath, cliOptions, {promiseConfig: true, throwErrors: true})` to prepare a processed `Config` instance and pass that as the `config` argument instead.
```