### PR TITLE
Silence karma filetype warnings

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,9 +26,18 @@ module.exports = function (config) {
     reporters: ['spec'],
 
     files: [
-      'spec/helpers/**/*.coffee',
-      'spec/**/*-behavior.coffee',
-      'spec/**/*-spec.coffee'
+      {
+        pattern: 'spec/helpers/**/*.coffee',
+        type: 'js'
+      },
+      {
+        pattern: 'spec/**/*-behavior.coffee',
+        type: 'js'
+      },
+      {
+        pattern: 'spec/**/*-spec.coffee',
+        type: 'js'
+      }
     ],
 
     preprocessors: {


### PR DESCRIPTION
Silence karma filetype warnings:
```
06 03 2024 12:16:10.041:WARN [middleware:karma]: Unable to determine file type from the file extension, defaulting to js.
  To silence the warning specify a valid type for /Users/georgewang/workspace/brainstem-js/spec/utils-spec.coffee in the configuration file.
  See https://karma-runner.github.io/latest/config/files.html
  ```