### PR TITLE
Update package.json to correct version of jasmine jquery matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-coffee": "^2.3.1",
     "gulp-util": "^3.0.7",
     "jasmine-core": "2.5.2",
-    "jasmine-jquery-matchers": "^1.1.1",
+    "jasmine-jquery-matchers": "^1.4.2",
     "karma": "^6.4.3",
     "karma-browserify": "^8.1.0",
     "karma-chrome-launcher": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,9 +2403,10 @@ jasmine-core@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.5.2.tgz#6f61bd79061e27f43e6f9355e44b3c6cab6ff297"
 
-jasmine-jquery-matchers@^1.1.1:
+jasmine-jquery-matchers@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jasmine-jquery-matchers/-/jasmine-jquery-matchers-1.4.2.tgz#023500a97520a927c99169f7f14a20a1a8a66281"
+  integrity sha512-hhTB2aspTRBz0+BnCW2jplG8Cnz7/3tJIaYcClU12S4QnGBDbnWoUnCCxA4CzaiVsTCxL1ZgmU3zrc1Pc99T1Q==
 
 jquery@2.2.4:
   version "2.2.4"


### PR DESCRIPTION
We are actually on 1.4.2. 