### PR TITLE
Prefer Object.assign to $.extend to merge objects

### DIFF
--- a/spec/helpers/builders.coffee
+++ b/spec/helpers/builders.coffee
@@ -30,7 +30,7 @@ spec.defineBuilders = ->
 
     factory = BackboneFactory.define(name, klass, -> return class_defaults)
     builder = (opts) ->
-      BackboneFactory.create(name, $.extend({}, class_defaults, idsToStrings(opts)))
+      BackboneFactory.create(name, Object.assign({}, class_defaults, idsToStrings(opts)))
 
     creator = (opts) ->
       storageManager = StorageManager.get()

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -1,3 +1,4 @@
+$ = require 'jquery'
 _ = require 'underscore'
 
 Collection = require '../collection'
@@ -39,7 +40,7 @@ class CollectionLoader extends AbstractLoader
     @externalObject = @loadOptions.collection || @storageManager.createNewCollection @loadOptions.name, []
     @externalObject.setLoaded false
     @externalObject.reset([], silent: false) if @loadOptions.reset
-    @externalObject.lastFetchOptions = _.pick(Object.assign(true, {}, @loadOptions), Collection.OPTION_KEYS)
+    @externalObject.lastFetchOptions = _.pick($.extend(true, {}, @loadOptions), Collection.OPTION_KEYS)
     @externalObject.lastFetchOptions.include = @originalOptions.include
 
   _updateObjects: (object, data, silent = false) ->

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -40,7 +40,7 @@ class CollectionLoader extends AbstractLoader
     @externalObject = @loadOptions.collection || @storageManager.createNewCollection @loadOptions.name, []
     @externalObject.setLoaded false
     @externalObject.reset([], silent: false) if @loadOptions.reset
-    @externalObject.lastFetchOptions = _.pick($.extend(true, {}, @loadOptions), Collection.OPTION_KEYS)
+    @externalObject.lastFetchOptions = _.pick(Object.assign(true, {}, @loadOptions), Collection.OPTION_KEYS)
     @externalObject.lastFetchOptions.include = @originalOptions.include
 
   _updateObjects: (object, data, silent = false) ->

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -1,4 +1,3 @@
-$ = require 'jquery'
 _ = require 'underscore'
 
 Collection = require '../collection'

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -92,7 +92,7 @@ class _StorageManager
   loadModel: (name, id, options = {}) ->
     return if not id
 
-    loader = @loadObject(name, $.extend({}, options, only: id), isCollection: false)
+    loader = @loadObject(name, Object.assign({}, options, only: id), isCollection: false)
     loader
 
   # Request a set of data to be loaded, optionally ensuring that associations be
@@ -113,14 +113,14 @@ class _StorageManager
 
   # Helpers
   loadObject: (name, loadOptions = {}, options = {}) ->
-    options = $.extend({}, { isCollection: true }, options)
+    options = Object.assign({}, { isCollection: true }, options)
 
     completeCallback = loadOptions.complete
     successCallback = loadOptions.success
     errorCallback = loadOptions.error
 
     loadOptions = _.omit(loadOptions, 'success', 'error', 'complete')
-    loadOptions = $.extend({}, loadOptions, name: name)
+    loadOptions = Object.assign({}, loadOptions, name: name)
 
     if options.isCollection
       loaderClass = CollectionLoader
@@ -155,7 +155,7 @@ class _StorageManager
   # brainstem AJAX response. Useful in avoiding unnecessary AJAX request(s) when rendering the page.
   bootstrap: (name, response, loadOptions = {}) ->
     loader = new CollectionLoader storageManager: this
-    loader.setup $.extend({}, loadOptions, name: name)
+    loader.setup Object.assign({}, loadOptions, name: name)
     loader._updateStorageManagerFromResponse response
 
   collectionError: (name) ->
@@ -179,10 +179,10 @@ class _StorageManager
       ')
 
   stubModel: (modelName, modelId, options = {}) ->
-    @stub(inflection.pluralize(modelName), $.extend({}, options, only: modelId))
+    @stub(inflection.pluralize(modelName), Object.assign({}, options, only: modelId))
 
   stubImmediate: (collectionName, options) ->
-    @stub collectionName, $.extend({}, options, immediate: true)
+    @stub collectionName, Object.assign({}, options, immediate: true)
 
   enableExpectations: ->
     @expectations = []

--- a/src/storage-manager.coffee
+++ b/src/storage-manager.coffee
@@ -1,7 +1,5 @@
 _ = require 'underscore'
-$ = require 'jquery'
 Backbone = require 'backbone'
-Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
 inflection = require 'inflection'
 
 Utils = require './utils'


### PR DESCRIPTION
Although `Object.assign` and `$.extend` have some differences (https://stackoverflow.com/questions/38345937/object-assign-vs-extend), the should not apply to us, as 1) we do not use the `deep: true` option in these methods, and 2) we are always merging in an empty object (`{}`), so it should never be undefined.