### PR TITLE
Remove jquery extend deep with lodash merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "inflection": "^3.0.0",
-    "jquery": "2.2.4"
+    "jquery": "2.2.4",
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "backbone": "1.0.0 - 1.1.2",

--- a/spec/helpers/spec-helper.coffee
+++ b/spec/helpers/spec-helper.coffee
@@ -2,7 +2,6 @@ $ = require 'jquery'
 _ = require 'underscore'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
-merge = require 'lodash.merge'
 
 jqueryMatchers = require 'jasmine-jquery-matchers'
 BackboneFactory = require 'backbone-factory'
@@ -33,7 +32,7 @@ window.convertTopLevelKeysToObjects = (data) ->
 
 window.respondWith = (server, url, options) ->
   if options.resultsFrom?
-    data = merge({}, options.data, { results: resultsArray(options.resultsFrom, options.data[options.resultsFrom]) })
+    data = $.extend {}, options.data, results: resultsArray(options.resultsFrom, options.data[options.resultsFrom])
   else
     data = options.data
   convertTopLevelKeysToObjects data

--- a/spec/helpers/spec-helper.coffee
+++ b/spec/helpers/spec-helper.coffee
@@ -2,6 +2,7 @@ $ = require 'jquery'
 _ = require 'underscore'
 Backbone = require 'backbone'
 Backbone.$ = $ # TODO remove after upgrading to backbone 1.2+
+merge = require 'lodash.merge'
 
 jqueryMatchers = require 'jasmine-jquery-matchers'
 BackboneFactory = require 'backbone-factory'
@@ -32,7 +33,7 @@ window.convertTopLevelKeysToObjects = (data) ->
 
 window.respondWith = (server, url, options) ->
   if options.resultsFrom?
-    data = $.extend {}, options.data, results: resultsArray(options.resultsFrom, options.data[options.resultsFrom])
+    data = merge({}, options.data, { results: resultsArray(options.resultsFrom, options.data[options.resultsFrom]) })
   else
     data = options.data
   convertTopLevelKeysToObjects data

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -40,7 +40,8 @@ class CollectionLoader extends AbstractLoader
     @externalObject = @loadOptions.collection || @storageManager.createNewCollection @loadOptions.name, []
     @externalObject.setLoaded false
     @externalObject.reset([], silent: false) if @loadOptions.reset
-    @externalObject.lastFetchOptions = _.pick($.extend(true, {}, @loadOptions), Collection.OPTION_KEYS)
+    loadOptions = $.extend(true, {}, @loadOptions)
+    @externalObject.lastFetchOptions = _.pick(loadOptions, Collection.OPTION_KEYS)
     @externalObject.lastFetchOptions.include = @originalOptions.include
 
   _updateObjects: (object, data, silent = false) ->

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -40,8 +40,7 @@ class CollectionLoader extends AbstractLoader
     @externalObject = @loadOptions.collection || @storageManager.createNewCollection @loadOptions.name, []
     @externalObject.setLoaded false
     @externalObject.reset([], silent: false) if @loadOptions.reset
-    loadOptions = merge({}, @loadOptions)
-    @externalObject.lastFetchOptions = _.pick(loadOptions, Collection.OPTION_KEYS)
+    @externalObject.lastFetchOptions = _.pick(merge({}, @loadOptions), Collection.OPTION_KEYS)
     @externalObject.lastFetchOptions.include = @originalOptions.include
 
   _updateObjects: (object, data, silent = false) ->

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -1,4 +1,3 @@
-$ = require 'jquery'
 _ = require 'underscore'
 merge = require 'lodash.merge'
 

--- a/src/loaders/collection-loader.coffee
+++ b/src/loaders/collection-loader.coffee
@@ -1,5 +1,6 @@
 $ = require 'jquery'
 _ = require 'underscore'
+merge = require 'lodash.merge'
 
 Collection = require '../collection'
 AbstractLoader = require './abstract-loader'
@@ -40,7 +41,7 @@ class CollectionLoader extends AbstractLoader
     @externalObject = @loadOptions.collection || @storageManager.createNewCollection @loadOptions.name, []
     @externalObject.setLoaded false
     @externalObject.reset([], silent: false) if @loadOptions.reset
-    loadOptions = $.extend(true, {}, @loadOptions)
+    loadOptions = merge({}, @loadOptions)
     @externalObject.lastFetchOptions = _.pick(loadOptions, Collection.OPTION_KEYS)
     @externalObject.lastFetchOptions.include = @originalOptions.include
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,6 +2630,11 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A==
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.template@^3.0.0, lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"


### PR DESCRIPTION
Brainstem has one instance of `$.extend` with the `deep: true` option, so replace it with `lodash.merge` to preserve deep merging behavior.

One remaining example of `$.extend` was also replaced with `lodash.merge` to avoid creating new objects in the response.

I decided to use a package instead of writing our own implementation to hopefully avoid subtle bugs with deep merging, handling undefined values, etc.