### PR TITLE
Allow any version of node 18 to allow ubuntu focal in builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "filename": "brainstem",
   "standalone": "Brainstem",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "Mavenlink",
     "email": "dev@mavenlink.com"
@@ -66,6 +66,6 @@
     "backbone": "global:Backbone"
   },
   "engines": {
-    "node": "^18.19.0"
+    "node": "^18"
   }
 }


### PR DESCRIPTION
The latest version of ubuntu focal runs node 18.17, so let's allow any version of node 18 until we can upgrade.